### PR TITLE
Upgrade chainsauce to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/yargs": "^17.0.22",
-    "chainsauce": "^1.0.4",
+    "chainsauce": "^1.0.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "ethers": "^5.7.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,7 +59,7 @@ const chains = {
     ],
   },
   fantom: {
-    rpc: `https://rpc.fantom.network`,
+    rpc: "https://rpcapi.fantom.network",
     subscriptions: [
       {
         address: "0x8e1bD5Da87C14dd8e08F7ecc2aBf9D1d558ea174",

--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -134,7 +134,7 @@ async function handleEvent(indexer: Indexer, event: Event) {
     }
 
     case "NewProjectApplication": {
-      const project = db
+      const project = await db
         .collection("projects")
         .findOneWhere((project) => project.fullId == event.args.project);
 
@@ -192,7 +192,7 @@ async function handleEvent(indexer: Indexer, event: Event) {
         ]
       );
 
-      const projectApplication = db
+      const projectApplication = await db
         .collection(`rounds/${event.address}/projects`)
         .findOneWhere((project) => project.id == event.args.projectId);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import { ethers } from "ethers";
-import { Log, createIndexer, JsonStorage, ToBlock } from "chainsauce";
+import {
+  RetryProvider,
+  Log,
+  createIndexer,
+  JsonStorage,
+  ToBlock,
+} from "chainsauce";
 import path from "node:path";
 import yargs from "yargs/yargs";
 
@@ -37,7 +43,11 @@ if (!chain) {
   process.exit(1);
 }
 
-const provider = new ethers.providers.JsonRpcProvider(chain.rpc);
+const provider = new RetryProvider({
+  url: chain.rpc,
+  timeout: 5 * 60 * 1000,
+});
+
 await provider.getNetwork();
 
 const storageDir = path.join(config.storageDir, `${provider.network.chainId}`);


### PR DESCRIPTION
- Use the new async API for the JsonStorage
- Use the new RetryProvider to auto retry failed provider calls for rate limiting or other reasons
- Update Fantom JSON-RPC endpoint