### PR TITLE
Handle Alchemy Rate Limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1538,9 +1538,9 @@
       }
     },
     "node_modules/chainsauce": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.15.tgz",
-      "integrity": "sha512-dTuU619ZeuMYR1Ga+oJTMOU/U9BPYYIX+6HS2Op+0LcV+9JsQ8mpm9tk6Qaa+hJujWw4rdzXcNn2DlFKRR/bfA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.16.tgz",
+      "integrity": "sha512-LRsnCQGodtqPDHzRhRx4pKMnOwLlcBQDUwgcoeLpbEyl6MQ2qEPFCKF2+VQydqXyc5ETnTr9pTbVfkz/5Dx85w==",
       "dependencies": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",
@@ -5529,9 +5529,9 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "chainsauce": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.15.tgz",
-      "integrity": "sha512-dTuU619ZeuMYR1Ga+oJTMOU/U9BPYYIX+6HS2Op+0LcV+9JsQ8mpm9tk6Qaa+hJujWw4rdzXcNn2DlFKRR/bfA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.16.tgz",
+      "integrity": "sha512-LRsnCQGodtqPDHzRhRx4pKMnOwLlcBQDUwgcoeLpbEyl6MQ2qEPFCKF2+VQydqXyc5ETnTr9pTbVfkz/5Dx85w==",
       "requires": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",


### PR DESCRIPTION
with Grants Stack usage increased because of the round, Alchemy sometimes rate limits us  because of the way they calculate compute units: https://docs.alchemy.com/reference/throughput

This implements exponential back off for rate limits when getting events: https://github.com/gitcoinco/chainsauce/commit/4b48d9e606c629c80f2e18653830f387810e70d3