### PR TITLE
Disable in memory cache

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -2,21 +2,11 @@ import config from "./config.js";
 import path from "node:path";
 import { JsonStorage } from "chainsauce";
 
-const databases = new Map<number, JsonStorage>();
-
 export default function load(chainId: number): JsonStorage {
-  let db = databases.get(chainId);
-
-  if (db) {
-    return db;
-  }
-
   if (config.chains.find((chain) => chain.id === chainId) === undefined) {
     throw new Error(`Chain ${chainId} not foound`);
   }
 
   const storageDir = path.join(config.storageDir, chainId.toString());
-  db = new JsonStorage(storageDir);
-  databases.set(chainId, db);
-  return db;
+  return new JsonStorage(storageDir);
 }


### PR DESCRIPTION
I haven't implemented auto refresh in the chainsauce database class yet, so when a Round is added after the rounds are loaded, these are not loaded again.

This disables the cache directly, so it will always load from the disk.

closes https://github.com/gitcoinco/grants-stack/issues/1779