### PR TITLE
Refactor Vote Coefficients

### DIFF
--- a/src/calculator/errors.ts
+++ b/src/calculator/errors.ts
@@ -1,0 +1,29 @@
+export class CalculatorError extends Error {
+  constructor(message?: string) {
+    super(message);
+  }
+}
+
+export class FileNotFoundError extends CalculatorError {
+  constructor(fileDescription: string) {
+    super(`cannot find ${fileDescription} file`);
+  }
+}
+
+export class ResourceNotFoundError extends CalculatorError {
+  constructor(resource: string) {
+    super(`${resource} not found`);
+  }
+}
+
+export class OverridesColumnNotFoundError extends CalculatorError {
+  constructor(column: string) {
+    super(`cannot find column ${column} in the overrides file`);
+  }
+}
+
+export class OverridesInvalidRowError extends CalculatorError {
+  constructor(row: number, message: string) {
+    super(`Row ${row} in the overrides file is invalid: ${message}`);
+  }
+}

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -200,9 +200,9 @@ export default class Calculator {
 
     const contributions: Array<Contribution> = votesWithCoefficients.flatMap(
       (vote) => {
-        const coefficient = BigInt(this.overrides[vote.id] ?? vote.coefficient);
+        const coefficient = this.overrides[vote.id] ?? vote.coefficient;
 
-        if (coefficient === 0n) {
+        if (coefficient === "0") {
           return [];
         }
 
@@ -210,7 +210,7 @@ export default class Calculator {
           {
             contributor: vote.voter,
             recipient: vote.applicationId,
-            amount: BigInt(vote.amountRoundToken) * coefficient,
+            amount: BigInt(vote.amountRoundToken),
           },
         ];
       }

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -1,57 +1,43 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import fs from "fs";
 import csv from "csv-parser";
 import { linearQF, Contribution, Calculation } from "pluralistic";
+import type { PassportScore } from "../passport/index.js";
 import { convertToUSD } from "../prices/index.js";
 import { tokenDecimals } from "../config.js";
-import type { Application, Vote } from "../indexer/types.js";
+import type { Round, Application, Vote } from "../indexer/types.js";
+import { getVotesWithCoefficients } from "./votes.js";
+import {
+  CalculatorError,
+  ResourceNotFoundError,
+  FileNotFoundError,
+  OverridesColumnNotFoundError,
+  OverridesInvalidRowError,
+} from "./errors.js";
 
-export class CalculatorError extends Error {
-  constructor(...args: any[]) {
-    super(...args);
-  }
-}
-
-export class FileNotFoundError extends CalculatorError {
-  constructor(fileDescription: string) {
-    super(`cannot find ${fileDescription} file`);
-  }
-}
-
-export class ResourceNotFoundError extends CalculatorError {
-  constructor(resource: string) {
-    super(`${resource} not found`);
-  }
-}
-
-export class OverridesColumnNotFoundError extends CalculatorError {
-  constructor(column: string) {
-    super(`cannot find column ${column} in the overrides file`);
-  }
-}
-
-export class OverridesInvalidRowError extends CalculatorError {
-  constructor(row: number, message: string) {
-    super(`Row ${row} in the overrides file is invalid: ${message}`);
-  }
-}
+export {
+  CalculatorError,
+  ResourceNotFoundError,
+  FileNotFoundError,
+  OverridesColumnNotFoundError,
+  OverridesInvalidRowError,
+};
 
 export interface DataProvider {
-  loadFile(description: string, path: string): Array<any>;
+  loadFile<T>(description: string, path: string): Array<T>;
 }
 
 export type Overrides = {
   [id: string]: string;
 };
 
-export class FileSystemDataProvider {
+export class FileSystemDataProvider implements DataProvider {
   basePath: string;
 
   constructor(basePath: string) {
     this.basePath = basePath;
   }
 
-  loadFile(description: string, path: string) {
+  loadFile<T>(description: string, path: string): Array<T> {
     const fullPath = `${this.basePath}/${path}`;
     if (!fs.existsSync(fullPath)) {
       throw new FileNotFoundError(description);
@@ -62,11 +48,11 @@ export class FileSystemDataProvider {
       flag: "r",
     });
 
-    return JSON.parse(data);
+    return JSON.parse(data) as Array<T>;
   }
 }
 
-export function parseOverrides(buf: Buffer): Promise<any> {
+export function parseOverrides(buf: Buffer): Promise<Overrides> {
   return new Promise((resolve, _reject) => {
     const results: Overrides = {};
     let rowIndex = 1;
@@ -105,7 +91,7 @@ export type CalculatorOptions = {
   dataProvider: DataProvider;
   chainId: number;
   roundId: string;
-  minimumAmount?: bigint;
+  minimumAmountUSD?: number;
   matchingCapAmount?: bigint;
   passportThreshold?: number;
   enablePassport?: boolean;
@@ -121,32 +107,11 @@ export type AugmentedResult = Calculation & {
   payoutAddress: string;
 };
 
-type ApplicationsMap = {
-  [id: string]: Application;
-};
-
-type RawRound = {
-  token: string;
-  id: string;
-  matchAmount: string;
-  matchAmountUSD: number;
-  metadata?: {
-    quadraticFundingConfig?: {
-      matchingFundsAvailable?: number;
-      sybilDefense?: boolean;
-      matchingCap?: boolean;
-      matchingCapAmount?: number;
-      minDonationThreshold?: boolean;
-      minDonationThresholdAmount?: number;
-    };
-  };
-};
-
 export default class Calculator {
   private dataProvider: DataProvider;
   private chainId: number;
   private roundId: string;
-  private minimumAmount: bigint | undefined;
+  private minimumAmountUSD: number | undefined;
   private matchingCapAmount: bigint | undefined;
   private enablePassport: boolean | undefined;
   private passportThreshold: number | undefined;
@@ -157,7 +122,7 @@ export default class Calculator {
     this.dataProvider = options.dataProvider;
     this.chainId = options.chainId;
     this.roundId = options.roundId;
-    this.minimumAmount = options.minimumAmount;
+    this.minimumAmountUSD = options.minimumAmountUSD;
     this.enablePassport = options.enablePassport;
     this.passportThreshold = options.passportThreshold;
     this.matchingCapAmount = options.matchingCapAmount;
@@ -166,29 +131,27 @@ export default class Calculator {
   }
 
   async calculate(): Promise<Array<AugmentedResult>> {
-    const rawContributions: Array<Vote> = this.parseJSONFile(
+    const votes = this.parseJSONFile<Vote>(
       "votes",
       `${this.chainId}/rounds/${this.roundId}/votes.json`
     );
-    const applications: ApplicationsMap = this.parseJSONFile(
+    const applications = this.parseJSONFile<Application>(
       "applications",
       `${this.chainId}/rounds/${this.roundId}/applications.json`
-    ).reduce((all, current) => {
-      all[current.id] = current;
-      return all;
-    }, {} as ApplicationsMap);
+    );
 
-    const rounds: RawRound[] = this.parseJSONFile(
+    const rounds = this.parseJSONFile<Round>(
       "rounds",
       `${this.chainId}/rounds.json`
     );
 
-    const passportScores = this.parseJSONFile(
+    const passportScores = this.parseJSONFile<PassportScore>(
       "passport scores",
       "passport_scores.json"
     );
 
-    const round = rounds.find((r: RawRound) => r.id === this.roundId);
+    const round = rounds.find((r: Round) => r.id === this.roundId);
+
     if (round === undefined) {
       throw new ResourceNotFoundError("round");
     }
@@ -203,21 +166,6 @@ export default class Calculator {
 
     const matchAmount = BigInt(round.matchAmount);
     const matchTokenDecimals = BigInt(tokenDecimals[this.chainId][round.token]);
-
-    const enablePassport =
-      this.enablePassport ??
-      round.metadata?.quadraticFundingConfig?.sybilDefense ??
-      false;
-
-    // 1. convert threshold amount to 6 decimals
-    // 2. truncate rest of decimals to bigint
-    // 3. convert decimals to token decimals
-    // 4. remove initial 6 decimals
-    const minimumAmount =
-      this.minimumAmount ??
-      Number(
-        round.metadata?.quadraticFundingConfig?.minDonationThresholdAmount ?? 0
-      );
 
     let matchingCapAmount = this.matchingCapAmount;
 
@@ -238,66 +186,35 @@ export default class Calculator {
         10000n;
     }
 
-    const isEligible = (addressData: any): boolean => {
-      const hasValidEvidence = addressData?.evidence?.success;
+    const votesWithCoefficients = await getVotesWithCoefficients(
+      round,
+      applications,
+      votes,
+      passportScores,
+      {
+        minimumAmountUSD: this.minimumAmountUSD,
+        enablePassport: this.enablePassport,
+        passportThreshold: this.passportThreshold,
+      }
+    );
 
-      if (enablePassport) {
-        if (typeof this.passportThreshold !== "undefined") {
-          return (
-            parseFloat(addressData?.evidence.rawScore ?? "0") >
-            this.passportThreshold
-          );
-        } else {
-          return Boolean(hasValidEvidence);
+    const contributions: Array<Contribution> = votesWithCoefficients.flatMap(
+      (vote) => {
+        const coefficient = BigInt(this.overrides[vote.id] ?? vote.coefficient);
+
+        if (coefficient === 0n) {
+          return [];
         }
+
+        return [
+          {
+            contributor: vote.voter,
+            recipient: vote.applicationId,
+            amount: BigInt(vote.amountRoundToken) * coefficient,
+          },
+        ];
       }
-      return true;
-    };
-
-    const passportIndex = passportScores.reduce((acc: any, ps: any) => {
-      acc[ps.address.toLowerCase()] = ps;
-      return acc;
-    }, {});
-
-    const contributions: Array<Contribution> = [];
-
-    for (let i = 0; i < rawContributions.length; i++) {
-      const raw = rawContributions[i];
-      const addressData = passportIndex[raw.voter.toLowerCase()];
-      const override = this.overrides[raw.id];
-
-      if (override === "0") {
-        continue;
-      }
-
-      if (applications[raw.applicationId].status !== "APPROVED") {
-        continue;
-      }
-
-      // only count contributions to the right payout address specified in the application metadata
-      const application = applications[raw.applicationId];
-      const payoutAddress = application?.metadata?.application?.recipient;
-      if (
-        payoutAddress === undefined ||
-        payoutAddress.toLowerCase() != raw.grantAddress.toLowerCase()
-      ) {
-        // skip if the application is not found or if the application payout address
-        // is different from the donation recipient
-        continue;
-      }
-
-      // only count contributions that are eligible by passport or the coefficient is 1
-      if (
-        override === "1" ||
-        (isEligible(addressData) && raw.amountUSD >= minimumAmount)
-      ) {
-        contributions.push({
-          contributor: raw.voter,
-          recipient: raw.applicationId,
-          amount: BigInt(raw.amountRoundToken),
-        });
-      }
-    }
+    );
 
     const results = linearQF(contributions, matchAmount, matchTokenDecimals, {
       minimumAmount: 0n,
@@ -307,9 +224,14 @@ export default class Calculator {
 
     const augmented: Array<AugmentedResult> = [];
 
+    const applicationsMap = applications.reduce((all, current) => {
+      all[current.id] = current;
+      return all;
+    }, {} as Record<string, Application>);
+
     for (const id in results) {
       const calc = results[id];
-      const application = applications[id];
+      const application = applicationsMap[id];
 
       const conversionUSD = await convertToUSD(
         this.chainId,
@@ -330,7 +252,7 @@ export default class Calculator {
     return augmented;
   }
 
-  parseJSONFile(fileDescription: string, path: string) {
-    return this.dataProvider.loadFile(fileDescription, path);
+  parseJSONFile<T>(fileDescription: string, path: string): Array<T> {
+    return this.dataProvider.loadFile<T>(fileDescription, path);
   }
 }

--- a/src/calculator/votes.ts
+++ b/src/calculator/votes.ts
@@ -70,7 +70,7 @@ export async function getVotesWithCoefficients(
           options.passportThreshold
       ) {
         passportCheckPassed = true;
-      } else if (passportScore.evidence?.success) {
+      } else if (passportScore?.evidence?.success) {
         passportCheckPassed = true;
       }
     } else {

--- a/src/calculator/votes.ts
+++ b/src/calculator/votes.ts
@@ -3,6 +3,7 @@ import type { PassportScore } from "../passport/index.js";
 
 type VoteWithCoefficient = Vote & {
   coefficient: number;
+  passportScore?: PassportScore;
 };
 
 export async function getVotesWithCoefficients(
@@ -39,7 +40,6 @@ export async function getVotesWithCoefficients(
 
   return votes.flatMap((vote) => {
     const voter = vote.voter.toLowerCase();
-    const score = passportScoresMap[voter];
     const application = applicationMap[vote.applicationId];
 
     // skip votes to applications that are not approved
@@ -60,15 +60,17 @@ export async function getVotesWithCoefficients(
 
     // Passport check
 
+    const passportScore = passportScoresMap[voter];
     let passportCheckPassed = false;
 
     if (enablePassport) {
       if (
         options.passportThreshold &&
-        Number(score?.evidence?.rawScore ?? "0") > options.passportThreshold
+        Number(passportScore?.evidence?.rawScore ?? "0") >
+          options.passportThreshold
       ) {
         passportCheckPassed = true;
-      } else if (score.evidence?.success) {
+      } else if (passportScore.evidence?.success) {
         passportCheckPassed = true;
       }
     } else {
@@ -89,12 +91,7 @@ export async function getVotesWithCoefficients(
       {
         ...vote,
         coefficient,
-        minimumAmountUSD: minimumAmountUSD,
-        passportLastScoreTimestamp: score?.last_score_timestamp,
-        passportRawScore: score?.evidence?.rawScore,
-        passportCheckType: score?.evidence?.type,
-        passportCheckSuccess: score?.evidence?.success,
-        passpportThreshold: score?.evidence?.threshold,
+        passportScore: passportScore,
       },
     ];
   });

--- a/src/calculator/votes.ts
+++ b/src/calculator/votes.ts
@@ -1,0 +1,101 @@
+import type { Round, Application, Vote } from "../indexer/types.js";
+import type { PassportScore } from "../passport/index.js";
+
+type VoteWithCoefficient = Vote & {
+  coefficient: number;
+};
+
+export async function getVotesWithCoefficients(
+  round: Round,
+  applications: Array<Application>,
+  votes: Array<Vote>,
+  passportScores: Array<PassportScore>,
+  options: {
+    minimumAmountUSD?: number;
+    enablePassport?: boolean;
+    passportThreshold?: number;
+  }
+): Promise<Array<VoteWithCoefficient>> {
+  const passportScoresMap = passportScores.reduce((map, score) => {
+    map[score.address.toLowerCase()] = score;
+    return map;
+  }, {} as Record<string, PassportScore>);
+
+  const applicationMap = applications.reduce((map, application) => {
+    map[application.id] = application;
+    return map;
+  }, {} as Record<string, Application>);
+
+  const enablePassport =
+    options.enablePassport ??
+    round?.metadata?.quadraticFundingConfig?.sybilDefense ??
+    false;
+
+  const minimumAmountUSD = Number(
+    options.minimumAmountUSD ??
+      round.metadata?.quadraticFundingConfig?.minDonationThresholdAmount ??
+      0
+  );
+
+  return votes.flatMap((vote) => {
+    const voter = vote.voter.toLowerCase();
+    const score = passportScoresMap[voter];
+    const application = applicationMap[vote.applicationId];
+
+    // skip votes to applications that are not approved
+    if (application?.status !== "APPROVED") {
+      return [];
+    }
+
+    const payoutAddress = application?.metadata?.application?.recipient;
+
+    // only count contributions to the right payout address specified in the application metadata
+    //
+    if (
+      payoutAddress === undefined ||
+      payoutAddress.toLowerCase() != vote.grantAddress.toLowerCase()
+    ) {
+      return [];
+    }
+
+    // Passport check
+
+    let passportCheckPassed = false;
+
+    if (enablePassport) {
+      if (
+        options.passportThreshold &&
+        Number(score?.evidence?.rawScore ?? "0") > options.passportThreshold
+      ) {
+        passportCheckPassed = true;
+      } else if (score.evidence?.success) {
+        passportCheckPassed = true;
+      }
+    } else {
+      passportCheckPassed = true;
+    }
+
+    // Minimum amount check
+
+    let minAmountCheckPassed = false;
+
+    if (vote.amountUSD >= minimumAmountUSD) {
+      minAmountCheckPassed = true;
+    }
+
+    const coefficient = passportCheckPassed && minAmountCheckPassed ? 1 : 0;
+
+    return [
+      {
+        ...vote,
+        coefficient,
+        minimumAmountUSD: minimumAmountUSD,
+        passportLastScoreTimestamp: score?.last_score_timestamp,
+        passportRawScore: score?.evidence?.rawScore,
+        passportCheckType: score?.evidence?.type,
+        passportCheckSuccess: score?.evidence?.success,
+        passpportThreshold: score?.evidence?.threshold,
+      },
+    ];
+  });
+}

--- a/src/database.ts
+++ b/src/database.ts
@@ -2,11 +2,16 @@ import config from "./config.js";
 import path from "node:path";
 import { JsonStorage } from "chainsauce";
 
-export default function load(chainId: number): JsonStorage {
-  if (config.chains.find((chain) => chain.id === chainId) === undefined) {
-    throw new Error(`Chain ${chainId} not foound`);
+export default function load(chainId?: number): JsonStorage {
+  let storageDir = config.storageDir;
+
+  if (chainId) {
+    if (config.chains.find((chain) => chain.id === chainId) === undefined) {
+      throw new Error(`Chain ${chainId} not foound`);
+    }
+
+    storageDir = path.join(storageDir, chainId.toString());
   }
 
-  const storageDir = path.join(config.storageDir, chainId.toString());
   return new JsonStorage(storageDir);
 }

--- a/src/http/api/v1/matches.ts
+++ b/src/http/api/v1/matches.ts
@@ -69,7 +69,7 @@ async function matchesHandler(
   const chainId = Number(req.params.chainId);
   const roundId = req.params.roundId;
 
-  const minimumAmount = req.query.minimumAmount?.toString();
+  const minimumAmountUSD = req.query.minimumAmountUSD?.toString();
   const passportThreshold = req.query.passportThreshold?.toString();
   const matchingCapAmount = req.query.matchingCapAmount?.toString();
 
@@ -99,7 +99,7 @@ async function matchesHandler(
     dataProvider: calculatorConfig.dataProvider,
     chainId: chainId,
     roundId: roundId,
-    minimumAmount: minimumAmount ? BigInt(minimumAmount) : undefined,
+    minimumAmountUSD: minimumAmountUSD ? Number(minimumAmountUSD) : undefined,
     matchingCapAmount: matchingCapAmount
       ? BigInt(matchingCapAmount)
       : undefined,

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -10,9 +10,13 @@ export type Round = {
   applicationMetadata: string | null;
   metaPtr: string;
   metadata: {
-    quadraticFundingConfig: {
-      sybilDefense: boolean;
-      minDonationThresholdAmount: number;
+    quadraticFundingConfig?: {
+      matchingFundsAvailable?: number;
+      sybilDefense?: boolean;
+      matchingCap?: boolean;
+      matchingCapAmount?: number;
+      minDonationThreshold?: boolean;
+      minDonationThresholdAmount?: number;
     };
   } | null;
   applicationsStartTime: number;

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -1,25 +1,23 @@
 import { wait } from "../utils/index.js";
 
-type PassportEvidence = {
-  type: string;
-  rawScore: string;
-  threshold: string;
-  success: boolean;
-};
-
-export type PassportResponse = {
+export type PassportScore = {
   address: string;
-  score?: string;
-  status?: string;
-  last_score_timestamp?: string;
-  evidence?: PassportEvidence;
+  score: string | null;
+  status: string;
+  last_score_timestamp: string;
+  evidence: {
+    type: string;
+    success: boolean;
+    rawScore: string;
+    threshold: string;
+  } | null;
   error?: string | null;
   detail?: string;
 };
 
 type PassportScoresResponse = {
   count: number;
-  passports: PassportResponse[];
+  passports: PassportScore[];
 };
 
 /**
@@ -44,7 +42,7 @@ export const getPassportScores = async () => {
     offset
   );
 
-  const allPassports: PassportResponse[] = passports;
+  const allPassports: PassportScore[] = passports;
 
   const paginationCount = count / limit;
 
@@ -70,8 +68,8 @@ export const getPassportScores = async () => {
  * @returns PassportResponse[]
  */
 export const filterPassportByEvidence = (
-  passports: PassportResponse[]
-): PassportResponse[] => {
+  passports: PassportScore[]
+): PassportScore[] => {
   return passports.filter(
     (passport) => passport.evidence && passport.evidence.success
   );
@@ -112,7 +110,7 @@ export const fetchPassportScores = async (
       const jsonResponse = (await response.json()) as any;
 
       const count: number = jsonResponse.count;
-      const passports: PassportResponse[] = jsonResponse.items;
+      const passports: PassportScore[] = jsonResponse.items;
 
       return {
         passports,


### PR DESCRIPTION
Most of the issues we've had with the coefficients has been a design issue, the calculator and the coefficient export have their own implementation, testing the vote coefficients doesn't guarantee the same results in the calculator.

**This PR is a refactor and doesn't change any functionality, I will make another PR to implement floating point coefficient on top of this for easy review.**

Summary of changes:

- Introduce a `getVotesWithCoefficients` source of truth function that will be called from the calculator and the CSV export handler
- Streamline Passport and Calculator types, remove all `any` and Eslint rule exception. Calculator is now fully type safe.
- Refactor vote data augmentation with passport to be more explicit with less spreads
- Refactor coefficient logic to be more explicit and easy to follow
- Rename `minimumAmount` to `minimumAmountUSD` since this naming caused a bit of confusion, this is a functionality change but we're not using it

I am confident this is not breaking anything but I would wait until beta rounds are finalized to merge.

# Topics of discussion for the group review

- I want to put forward this example as a way for us to improve the codebase and implement features at the same time
     - Refactors have to go in a different PR and should not change functionality, ideally done before the feature
     - Smaller refactors could be done within the feature PR if the code is related
     - Use `git add -p` and `git stash` to your advantage
- Let's walk through some of the issues we had in the calculations that this PR fixes.
   - We can see that they were mostly caused by errors in the business logic.
   - We should spend some time thinking about the feature we're implementing, and thinking how we can integrate it in the existing codebase instead of just implementing it on top.
   - Wrongly named variables can cause bugs, let's put more thought into names.
