### PR TITLE
Update passport scores every hour

### DIFF
--- a/src/cli/passport.ts
+++ b/src/cli/passport.ts
@@ -11,7 +11,7 @@ import {
   getPassportScores,
 } from "../passport/index.js";
 
-const { values } = parseArgs({
+const { values: args } = parseArgs({
   options: {
     follow: {
       type: "boolean",
@@ -20,7 +20,32 @@ const { values } = parseArgs({
   },
 });
 
+// Update every hour
+const updateEveryMs = 60 * 60 * 1000;
+
 async function getScoresAndWrite(dir: string) {
+  let isOutdated = false;
+
+  try {
+    const stats = await Promise.all([
+      fs.stat(path.join(dir, "passport_scores.json")),
+      fs.stat(path.join(dir, "passport_valid_addresses.json")),
+    ]);
+
+    isOutdated = stats.some(
+      (stat) => Date.now() - stat.mtimeMs > updateEveryMs
+    );
+  } catch (e) {
+    isOutdated = true;
+  }
+
+  if (!isOutdated) {
+    console.log("Passport scores are up to date, skipping");
+    return;
+  }
+
+  console.log("Fetching passport scores...");
+
   const scores = await getPassportScores();
 
   const validAddresses = filterPassportByEvidence(scores).map((passport) => {
@@ -41,10 +66,11 @@ async function getScoresAndWrite(dir: string) {
 async function loop() {
   await getScoresAndWrite(config.storageDir);
 
-  setTimeout(loop, 60 * 60 * 1000);
+  // loop every minute
+  setTimeout(loop, 60 * 1000);
 }
 
-if (values.follow) {
+if (args.follow) {
   await loop();
 } else {
   await getScoresAndWrite(config.storageDir);


### PR DESCRIPTION
At the moment every time you run the passport script it will fetch all the scores, even if they've just been fetched, which means when we deploy we fetch them twice, once to build the Docker image and then to deploy again. It shouldn't update the scores if they're not more than 1 hour old.