### PR TITLE
Crash on async errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@sentry/node": "^7.51.0",
-        "chainsauce": "^1.0.18",
+        "chainsauce": "1.0.19",
         "cors": "^2.8.5",
         "csv-parser": "^3.0.0",
         "csv-writer": "^1.6.0",
@@ -2268,9 +2268,9 @@
       }
     },
     "node_modules/chainsauce": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.18.tgz",
-      "integrity": "sha512-C9x7OztVHA3T5V9ncso0qNRjqkbarVgh43/WhAWhDEpiqce4Ytqy8U7b+b9hLhar++OuzPEYSZTiXdmGBPxBjQ==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.19.tgz",
+      "integrity": "sha512-Ff5C6UWXMo0z1PdW/6LjHYyKM3kVx0pwmbwVn/2ryqlbSdAzf4f5g9i+VEr1Dc6xyNlzHVkq556Cd+/EOHiH9Q==",
       "dependencies": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",
@@ -7188,9 +7188,9 @@
       }
     },
     "chainsauce": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.18.tgz",
-      "integrity": "sha512-C9x7OztVHA3T5V9ncso0qNRjqkbarVgh43/WhAWhDEpiqce4Ytqy8U7b+b9hLhar++OuzPEYSZTiXdmGBPxBjQ==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/chainsauce/-/chainsauce-1.0.19.tgz",
+      "integrity": "sha512-Ff5C6UWXMo0z1PdW/6LjHYyKM3kVx0pwmbwVn/2ryqlbSdAzf4f5g9i+VEr1Dc6xyNlzHVkq556Cd+/EOHiH9Q==",
       "requires": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "ISC",
   "dependencies": {
     "@sentry/node": "^7.51.0",
-    "chainsauce": "^1.0.18",
+    "chainsauce": "1.0.19",
     "cors": "^2.8.5",
     "csv-parser": "^3.0.0",
     "csv-writer": "^1.6.0",


### PR DESCRIPTION
Because async event handlers are not being awaited on, promise rejections don't crash the Node process.

This updates Chainsauce with a fix to crash the process when an async error happens: https://github.com/chainsauce-org/chainsauce/commit/2faa18b31db44f0056717a80f0d5256f78eb754e

In Chasinsauce in the future this will probably be an event handler on the indexer so the client can choose what to do with errors, but for now this solves our problem.