### PR TITLE
Staging and storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,31 @@ jobs:
             --build-secret IPFS_GATEWAY=${{ secrets.IPFS_GATEWAY }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy Staging
+        run: |
+          flyctl -c fly.staging.toml deploy \
+            --remote-only \
+            --build-secret INFURA_API_KEY=${{ secrets.INFURA_API_KEY }} \
+            --build-secret ALCHEMY_API_KEY=${{ secrets.ALCHEMY_API_KEY }} \
+            --build-secret PASSPORT_API_KEY=${{ secrets.PASSPORT_API_KEY }} \
+            --build-secret PASSPORT_SCORER_ID=${{ secrets.PASSPORT_SCORER_ID }} \
+            --build-secret COINGECKO_API_KEY=${{ secrets.COINGECKO_API_KEY }} \
+            --build-secret IPFS_GATEWAY=${{ secrets.IPFS_GATEWAY }}
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy Production
+        run: |
+          flyctl -c fly.toml deploy \
+            --remote-only \
+            --build-secret INFURA_API_KEY=${{ secrets.INFURA_API_KEY }} \
+            --build-secret ALCHEMY_API_KEY=${{ secrets.ALCHEMY_API_KEY }} \
+            --build-secret PASSPORT_API_KEY=${{ secrets.PASSPORT_API_KEY }} \
+            --build-secret PASSPORT_SCORER_ID=${{ secrets.PASSPORT_SCORER_ID }} \
+            --build-secret COINGECKO_API_KEY=${{ secrets.COINGECKO_API_KEY }} \
+            --build-secret IPFS_GATEWAY=${{ secrets.IPFS_GATEWAY }}
+        if: ${{ github.ref == 'refs/heads/release' }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,42 +18,20 @@ jobs:
 
       - name: Build
         run: |
-          flyctl deploy \
-            --remote-only \
-            --build-only \
-            --build-secret INFURA_API_KEY=${{ secrets.INFURA_API_KEY }} \
-            --build-secret ALCHEMY_API_KEY=${{ secrets.ALCHEMY_API_KEY }} \
-            --build-secret PASSPORT_API_KEY=${{ secrets.PASSPORT_API_KEY }} \
-            --build-secret PASSPORT_SCORER_ID=${{ secrets.PASSPORT_SCORER_ID }} \
-            --build-secret COINGECKO_API_KEY=${{ secrets.COINGECKO_API_KEY }} \
-            --build-secret IPFS_GATEWAY=${{ secrets.IPFS_GATEWAY }}
+          flyctl deploy --remote-only --build-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Deploy Staging
+      - name: Deploy to Staging
         run: |
-          flyctl -c fly.staging.toml deploy \
-            --remote-only \
-            --build-secret INFURA_API_KEY=${{ secrets.INFURA_API_KEY }} \
-            --build-secret ALCHEMY_API_KEY=${{ secrets.ALCHEMY_API_KEY }} \
-            --build-secret PASSPORT_API_KEY=${{ secrets.PASSPORT_API_KEY }} \
-            --build-secret PASSPORT_SCORER_ID=${{ secrets.PASSPORT_SCORER_ID }} \
-            --build-secret COINGECKO_API_KEY=${{ secrets.COINGECKO_API_KEY }} \
-            --build-secret IPFS_GATEWAY=${{ secrets.IPFS_GATEWAY }}
+          flyctl -c fly.staging.toml deploy --remote-only --wait-timeout=600
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Deploy Production
+      - name: Deploy to Production
         run: |
-          flyctl -c fly.toml deploy \
-            --remote-only \
-            --build-secret INFURA_API_KEY=${{ secrets.INFURA_API_KEY }} \
-            --build-secret ALCHEMY_API_KEY=${{ secrets.ALCHEMY_API_KEY }} \
-            --build-secret PASSPORT_API_KEY=${{ secrets.PASSPORT_API_KEY }} \
-            --build-secret PASSPORT_SCORER_ID=${{ secrets.PASSPORT_SCORER_ID }} \
-            --build-secret COINGECKO_API_KEY=${{ secrets.COINGECKO_API_KEY }} \
-            --build-secret IPFS_GATEWAY=${{ secrets.IPFS_GATEWAY }}
+          flyctl -c fly.toml deploy --remote-only  --wait-timeout=600
         if: ${{ github.ref == 'refs/heads/release' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,20 +21,4 @@ COPY seed seed
 
 RUN npm run test
 
-# Cache indexer in the image
-RUN --mount=type=secret,id=INFURA_API_KEY \
-    --mount=type=secret,id=ALCHEMY_API_KEY \
-    --mount=type=secret,id=PASSPORT_API_KEY \
-    --mount=type=secret,id=PASSPORT_SCORER_ID \
-    --mount=type=secret,id=COINGECKO_API_KEY \
-    --mount=type=secret,id=IPFS_GATEWAY \
-    --mount=type=cache,target=/usr/src/app/.cache \
-    INFURA_API_KEY=$(cat /run/secrets/INFURA_API_KEY) \
-    ALCHEMY_API_KEY=$(cat /run/secrets/ALCHEMY_API_KEY) \
-    PASSPORT_API_KEY=$(cat /run/secrets/PASSPORT_API_KEY) \
-    PASSPORT_SCORER_ID=$(cat /run/secrets/PASSPORT_SCORER_ID) \
-    COINGECKO_API_KEY=$(cat /run/secrets/COINGECKO_API_KEY) \
-    IPFS_GATEWAY=$(cat /run/secrets/IPFS_GATEWAY) \
-    npm run index:all -- 'npm:passport'
-
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -71,13 +71,22 @@ npm run passport # index passport scores
 
 ## Deployment
 
-The indexer is currently automatically deployed on [Fly.io](Fly.io) from the `main` branch. We reindex everything from scratch on each deploy, we only persist the cache, which includes events and IPFS data.
+We deploy the Docker image to Fly, check [fly.toml](https://github.com/gitcoinco/allo-indexer/blob/main/fly.toml) and [Dockerfile](https://github.com/gitcoinco/allo-indexer/blob/main/Dockerfile) files for more details.
 
-The following commands might be useful for monitoring production:
+**Notes about the deployment**
+
+- `main` continuously deploys to https://indexer-staging.fly.dev/
+- `release` continuously deploys to https://indexer-grants-stack.gitcoin.co/data/
+- On deploy the data directory is always cleared and everything is reindexed, we only persist the cache
+- Find the data directory at `/mnt/indexer/data` and the cache directory at `/mnt/indexer/cache`
+
+The following commands might be useful for monitoring (use the `-c [fly.toml|fly.staging.toml]` argument switch between staging and production:
 
 ```bash
 fly status # show general status of the app, all VMs and their status
+fly -c fly.staging.toml status # status of staging
 fly logs # check logs of running VM, it also shows logs of deployments in progress
+fly -c fly.staging.toml logs # check logs of staging
 fly ssh console # open a console to the runnning VM
 ```
 

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,0 +1,41 @@
+app = "indexer-staging"
+kill_signal = "SIGINT"
+kill_timeout = 5
+primary_region = "den"
+
+[env]
+  PORT = "8080"
+  STORAGE_DIR = "/mnt/indexer/data"
+  CACHE_DIR = "/mnt/indexer/cache"
+
+[processes]
+  web = "npm start"
+
+[mounts]
+  source="indexer_staging"
+  destination="/mnt/indexer"
+
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8080
+  processes = ["web"]
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.tcp_checks]]
+    interval = "15s"
+    timeout = "10s"
+    grace_period = "20m0s"
+    restart_limit = 0

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -9,12 +9,11 @@ primary_region = "den"
   CACHE_DIR = "/mnt/indexer/cache"
 
 [processes]
-  web = "npm start"
+  web = "sh -c 'rm -rf $STORAGE_DIR/* && npm start'"
 
 [mounts]
   source="indexer_staging"
   destination="/mnt/indexer"
-
 
 [[services]]
   protocol = "tcp"
@@ -35,7 +34,6 @@ primary_region = "den"
     soft_limit = 20
 
   [[services.tcp_checks]]
-    interval = "15s"
+    interval = "60s"
     timeout = "10s"
-    grace_period = "20m0s"
-    restart_limit = 0
+    grace_period = "1m"

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,7 +1,10 @@
 app = "indexer-staging"
+primary_region = "den"
 kill_signal = "SIGINT"
 kill_timeout = 5
-primary_region = "den"
+
+[experimental]
+  auto_rollback = true
 
 [env]
   PORT = "8080"
@@ -34,6 +37,6 @@ primary_region = "den"
     soft_limit = 20
 
   [[services.tcp_checks]]
-    interval = "60s"
+    interval = "30s"
     timeout = "10s"
     grace_period = "1m"

--- a/fly.toml
+++ b/fly.toml
@@ -1,42 +1,43 @@
-app = "grants-stack-indexer"
+app = "indexer-production"
+primary_region = "den"
 kill_signal = "SIGINT"
 kill_timeout = 5
-primary_region = "den"
-processes = []
-
-[processes]
-web = "npm start"
-
-[env]
-  PORT = "8080"
-  STORAGE_DIR = "./data"
 
 [experimental]
   auto_rollback = true
 
+[env]
+  PORT = "8080"
+  STORAGE_DIR = "/mnt/indexer/data"
+  CACHE_DIR = "/mnt/indexer/cache"
+
+[processes]
+  web = "sh -c 'rm -rf $STORAGE_DIR/* && npm start'"
+
+[mounts]
+  source="indexer_production"
+  destination="/mnt/indexer"
+
 [[services]]
-  http_checks = []
+  protocol = "tcp"
   internal_port = 8080
   processes = ["web"]
-  protocol = "tcp"
-  script_checks = []
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
 
   [services.concurrency]
+    type = "connections"
     hard_limit = 25
     soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
 
   [[services.tcp_checks]]
-    grace_period = "1200s"
-    interval = "15s"
-    restart_limit = 0
+    interval = "30s"
     timeout = "10s"
+    grace_period = "1m"

--- a/src/cli/indexer.ts
+++ b/src/cli/indexer.ts
@@ -125,7 +125,7 @@ if (args.follow) {
 const indexer = await createIndexer(provider, storage, handleEvent, {
   toBlock,
   logLevel,
-  eventCacheDirectory: args["no-cache"] ? null : "./.cache",
+  eventCacheDirectory: args["no-cache"] ? null : config.cacheDir,
   runOnce: !args.follow,
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,6 +220,7 @@ export const eventRenames = Object.fromEntries(
 
 export default {
   storageDir: process.env.STORAGE_DIR || "./data",
+  cacheDir: process.env.CACHE_DIR || "./.cache",
   port: Number(process.env.PORT || "4000"),
   ipfsGateway: process.env.IPFS_GATEWAY || "https://cloudflare-ipfs.com",
   coingeckoApiKey: process.env.COINGECKO_API_KEY,


### PR DESCRIPTION
fixes #90 
fixes #88 

We now have two apps in Fly, one for staging and another for production.

- `main` continuously deploys to https://indexer-staging.fly.dev/
- `release` continuously deploys to https://indexer-production.fly.dev/
- On deploy the data directory is always cleared and everything is reindexed, we only persist the cache
- In the VM,fFind the data directory at `/mnt/indexer/data` and the cache directory at `/mnt/indexer/cache`