### PR TITLE
Return calculator errors to the client

### DIFF
--- a/src/calculator/errors.ts
+++ b/src/calculator/errors.ts
@@ -1,6 +1,8 @@
-export class CalculatorError extends Error {
-  constructor(message?: string) {
-    super(message);
+import ClientError from "../http/api/clientError.js";
+
+export class CalculatorError extends ClientError {
+  constructor(message: string) {
+    super(message, 400);
   }
 }
 

--- a/src/calculator/errors.ts
+++ b/src/calculator/errors.ts
@@ -1,20 +1,20 @@
 import ClientError from "../http/api/clientError.js";
 
 export class CalculatorError extends ClientError {
-  constructor(message: string) {
-    super(message, 400);
+  constructor(message: string, status = 400) {
+    super(message, status);
   }
 }
 
 export class FileNotFoundError extends CalculatorError {
   constructor(fileDescription: string) {
-    super(`cannot find ${fileDescription} file`);
+    super(`cannot find ${fileDescription} file`, 404);
   }
 }
 
 export class ResourceNotFoundError extends CalculatorError {
   constructor(resource: string) {
-    super(`${resource} not found`);
+    super(`${resource} not found`, 404);
   }
 }
 

--- a/src/http/api/v1/index.ts
+++ b/src/http/api/v1/index.ts
@@ -13,7 +13,7 @@ router.use(exports);
 router.use(matches);
 
 // handle uncaught errors
-router.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+router.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   // return client errors
   if (err instanceof ClientError) {
     res.status(err.status);


### PR DESCRIPTION
The express app automatically returns `ClientError` instances as a JSON object with the error details, other errors are silenced and we just return `something went wrong`.

This also fixes override file errors to be logged by sentry as they're expected errors.

Check the error handler here: https://github.com/gitcoinco/allo-indexer/blob/fix/calculator-error-is-a-client-error/src/http/api/v1/index.ts#L16