### PR TITLE
Diff indexer endpoints script

### DIFF
--- a/diff.sh
+++ b/diff.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+A=`mktemp`
+B=`mktemp`
+DIFF=`mktemp`
+
+curl -s $1 | jq . > $A
+curl -s $2 | jq . > $B
+
+# piping to less truncates the output, so we write to a file
+# use the -f flag to show full diff
+npx json-diff --color $A $B > $DIFF
+less -r --RAW-CONTROL-CHARS $DIFF
+
+rm $A $B $DIFF

--- a/diff.sh
+++ b/diff.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <old_url> <new_url>"
+  exit 1
+fi
+
 A=`mktemp`
 B=`mktemp`
 DIFF=`mktemp`
+
+trap "rm $A $B $DIFF" EXIT
 
 curl -s $1 | jq . > $A
 curl -s $2 | jq . > $B
@@ -11,5 +18,3 @@ curl -s $2 | jq . > $B
 # use the -f flag to show full diff
 npx json-diff --color $A $B > $DIFF
 less -r --RAW-CONTROL-CHARS $DIFF
-
-rm $A $B $DIFF


### PR DESCRIPTION
closes https://github.com/gitcoinco/allo-indexer/issues/99


This adds a handy script to diff two endpoints, like `git diff` but for JSON URLs.


The idea behind this is to use it to manually compare the staging indexer with the production indexer to see what changed before deploying big changes, especially changes to the matching calculator.

```
$ ./diff.sh # to see usage
$ ./diff.sh https://indexer-grants-stack.gitcoin.co/data/1/rounds/0x12BB5bBbFE596dbc489d209299B8302c3300fa40/applications.json https://indexer-staging.fly.dev/data/1/rounds/0x12BB5bBbFE596dbc489d209299B8302c3300fa40/applications.json
$ ./diff.sh https://indexer-grants-stack.gitcoin.co/data/1/rounds.json https://indexer-staging.fly.dev/data/1/rounds.json
$ ./diff.sh https://indexer-grants-stack.gitcoin.co/api/v1/chains/1/rounds/0x12BB5bBbFE596dbc489d209299B8302c3300fa40/matches https://indexer-staging.fly.dev/api/v1/chains/1/rounds/0x12BB5bBbFE596dbc489d209299B8302c3300fa40/matches
```

You get colored output and all:

<img width="854" alt="Screenshot 2023-06-22 at 21 11 11" src="https://github.com/gitcoinco/allo-indexer/assets/711886/fccde4ac-a754-4c68-a4c5-72c6da0b89aa">

