### PR TITLE
Update dev script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ npm start # this runs the production start script which will index all chains an
 
 **Make sure you set the environment variables before running, find a `.env` template in `.env.example`**
 
-
 ```bash
 npm install
-npm start:dev # run the typescript compiler and the HTTP server
+npm run dev # run the typescript compiler and the HTTP server
 ```
 
 The HTTP server runs on port 4000, check it here: http://localhost:4000/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/src/indexer/index.d.ts",
   "scripts": {
     "start": "concurrently --kill-others-on-fail 'npm:index:all -- --kill-others-on-fail -- --log-level=error --clear' 'npm:passport' && echo '======> Index successful, running server!' && concurrently 'npm:index:all -- -- --follow' 'npm:passport -- --follow' 'npm:serve'",
-    "start:dev": "concurrently -P --kill-others -n \"tsc,http\" \"npm:build:dev\" \"npm:serve:dev\"",
+    "dev": "concurrently -P --kill-others -n \"tsc,http\" \"npm:build:dev\" \"npm:serve:dev\"",
     "build": "tsc",
     "build:dev": "tsc --watch",
     "lint": "eslint src",


### PR DESCRIPTION
I initially named the dev script `start:dev` with the idea that all scripts are prod by default and then you add the `:dev` suffix to make it development.

But the common naming convention for the main dev script is just `npm run dev`, so I propose we use that to make it more obvious to everyone and be consistent with the node ecosystem.