### PR TITLE
Trigger Github Actions on push in release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release]
 
   pull_request:
     branches: "**"


### PR DESCRIPTION
Only main is triggered at the moment, which deploys to staging. Release should trigger a deploy to production.