### PR TITLE
Lowercase voter address in the vote coefficient export

### DIFF
--- a/src/calculator/votes.ts
+++ b/src/calculator/votes.ts
@@ -90,6 +90,7 @@ export async function getVotesWithCoefficients(
     return [
       {
         ...vote,
+        voter,
         coefficient,
         passportScore: passportScore,
       },


### PR DESCRIPTION
We're returning the voter in checksum format, we want to keep the export backwards compatible with the current production indexer, which returns it lowercased.