### PR TITLE
Improve Start Script Readibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,6 @@ COPY seed seed
 
 RUN npm run test
 
+COPY start.sh ./
+
 CMD [ "npm", "start" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^5.55.0",
         "@typescript-eslint/parser": "^5.55.0",
-        "concurrently": "^8.0.1",
+        "concurrently": "^8.2.0",
         "eslint": "^8.36.0",
         "nodemon": "^2.0.22",
         "prettier": "^2.8.4",
@@ -2443,20 +2443,20 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.0.1.tgz",
-      "integrity": "sha512-Sh8bGQMEL0TAmAm2meAXMjcASHZa7V0xXQVDBLknCPa9TPtkY9yYs+0cnGGgfdkW0SV1Mlg+hVGfXcoI8d3MJA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.0.tgz",
+      "integrity": "sha512-nnLMxO2LU492mTUj9qX/az/lESonSZu81UznYDoXtz1IQf996ixVqPAgHXwvHiHCAef/7S8HIK+fTFK7Ifk8YA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
-        "date-fns": "^2.29.3",
+        "date-fns": "^2.30.0",
         "lodash": "^4.17.21",
-        "rxjs": "^7.8.0",
-        "shell-quote": "^1.8.0",
-        "spawn-command": "0.0.2-1",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
         "supports-color": "^8.1.1",
         "tree-kill": "^1.2.2",
-        "yargs": "^17.7.1"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "conc": "dist/bin/concurrently.js",
@@ -4932,9 +4932,10 @@
       "license": "ISC"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5048,9 +5049,9 @@
       }
     },
     "node_modules/spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
     "node_modules/stackback": {
@@ -7333,20 +7334,20 @@
       }
     },
     "concurrently": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.0.1.tgz",
-      "integrity": "sha512-Sh8bGQMEL0TAmAm2meAXMjcASHZa7V0xXQVDBLknCPa9TPtkY9yYs+0cnGGgfdkW0SV1Mlg+hVGfXcoI8d3MJA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.0.tgz",
+      "integrity": "sha512-nnLMxO2LU492mTUj9qX/az/lESonSZu81UznYDoXtz1IQf996ixVqPAgHXwvHiHCAef/7S8HIK+fTFK7Ifk8YA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
-        "date-fns": "^2.29.3",
+        "date-fns": "^2.30.0",
         "lodash": "^4.17.21",
-        "rxjs": "^7.8.0",
-        "shell-quote": "^1.8.0",
-        "spawn-command": "0.0.2-1",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
         "supports-color": "^8.1.1",
         "tree-kill": "^1.2.2",
-        "yargs": "^17.7.1"
+        "yargs": "^17.7.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8972,7 +8973,9 @@
       "version": "1.2.0"
     },
     "shell-quote": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
     },
     "side-channel": {
@@ -9039,9 +9042,9 @@
       "dev": true
     },
     "spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
     "stackback": {

--- a/package.json
+++ b/package.json
@@ -6,20 +6,18 @@
   "main": "dist/src/indexer/index.js",
   "types": "dist/src/indexer/index.d.ts",
   "scripts": {
-    "start": "concurrently --kill-others-on-fail 'npm:index:all -- --kill-others-on-fail -- --log-level=error --clear' 'npm:passport' && echo '======> Index successful, running server!' && concurrently 'npm:index:all -- -- --follow' 'npm:passport -- --follow' 'npm:serve'",
+    "start": "./start.sh",
     "dev": "concurrently -P --kill-others -n \"tsc,http\" \"npm:build:dev\" \"npm:serve:dev\"",
     "build": "tsc",
-    "build:dev": "tsc --watch",
+    "build:watch": "tsc --watch",
     "lint": "eslint src",
     "format": "prettier --write src",
     "test": "vitest run --reporter verbose",
-    "test:dev": "vitest watch --reporter verbose",
+    "test:watch": "vitest watch --reporter verbose",
     "serve": "node dist/src/http/server.js",
-    "serve:dev": "nodemon --delay 2 --watch dist --exec 'npm run serve -- '",
+    "serve:watch": "nodemon --delay 2 --watch dist --exec 'npm run serve -- '",
     "passport": "node dist/src/cli/passport.js",
-    "index": "node dist/src/cli/indexer.js",
-    "index:dev": "nodemon --delay 2 --watch dist --exec 'npm run index -- '",
-    "index:all": "concurrently --raw -P 'npm:index -- --chain=mainnet {@}' 'npm:index -- --chain=optimism {@}' 'npm:index -- --chain=goerli {@}' 'npm:index -- --chain=fantom {@}'"
+    "index": "node dist/src/cli/indexer.js"
   },
   "imports": {
     "#abis/*": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.55.0",
-    "concurrently": "^8.0.1",
+    "concurrently": "^8.2.0",
     "eslint": "^8.36.0",
     "nodemon": "^2.0.22",
     "prettier": "^2.8.4",

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# Exit script on interrupts
+trap "exit 130" INT
+
+echo "======> Catching up"
+
+# Catch up indexers to latest block before starting
+npx concurrently \
+  --kill-others-on-fail \
+  --names "mainnet,optimism,goerli,fantom,passport" \
+  'npm:index -- --chain=mainnet --log-level=error --clear' \
+  'npm:index -- --chain=optimism --log-level=error --clear' \
+  'npm:index -- --chain=goerli --log-level=error --clear' \
+  'npm:index -- --chain=fantom --log-level=error --clear' \
+  'npm:passport'
+
+echo "======> Catch up successful, running indexer on follow mode!"
+
+# Once caught up, start indexers in follow mode and run HTTP server
+exec npx concurrently \
+  --restart-retires=10 \
+  --names "mainnet,optimism,goerli,fantom,passport,http" \
+  'npm:index -- --chain=mainnet --follow' \
+  'npm:index -- --chain=optimism --follow' \
+  'npm:index -- --chain=goerli --follow' \
+  'npm:index -- --chain=fantom --follow' \
+  'npm:passport -- --restart--retries=10 --follow' \
+  'npm:serve'

--- a/start.sh
+++ b/start.sh
@@ -21,7 +21,7 @@ echo "======> Catch up successful, running indexer on follow mode!"
 
 # Once caught up, start indexers in follow mode and run HTTP server
 exec npx concurrently \
-  --restart-retires=10 \
+  --restart-tries=10 \
   --names "mainnet,optimism,goerli,fantom,passport,http" \
   'npm:index -- --chain=mainnet --follow' \
   'npm:index -- --chain=optimism --follow' \

--- a/start.sh
+++ b/start.sh
@@ -30,5 +30,5 @@ exec npx concurrently \
   'npm:index -- --chain=optimism --follow' \
   'npm:index -- --chain=goerli --follow' \
   'npm:index -- --chain=fantom --follow' \
-  'npm:passport -- --restart--retries=10 --follow' \
+  'npm:passport -- --follow' \
   'npm:serve'

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,9 @@ trap "exit 130" INT
 
 echo "======> Catching up"
 
-# Catch up indexers to latest block before starting
+# Catch up indexers to latest block first,
+# do not run the HTTP server, as we don't want to serve traffic
+# because data won't be up to date yet
 npx concurrently \
   --kill-others-on-fail \
   --names "mainnet,optimism,goerli,fantom,passport" \
@@ -19,7 +21,8 @@ npx concurrently \
 
 echo "======> Catch up successful, running indexer on follow mode!"
 
-# Once caught up, start indexers in follow mode and run HTTP server
+# Once caught up, start indexers in follow mode and run HTTP server,
+# we can now start serving traffic
 exec npx concurrently \
   --restart-tries=10 \
   --names "mainnet,optimism,goerli,fantom,passport,http" \


### PR DESCRIPTION
I hope I am forgiven for one last command refactor:

- Split out the horrendous start command into a bash script so it can be more readable and easier to understand what the application is doing in production (yes we're going back to a bash script 🙃 )
- Add `--restart-tries` option to Concurrently so that it restarts scripts when they die, I thought this was a default option. I thought 10 was a sensible option.
- Remove the `index:all` command and do it manually instead, more code but it should hopefully be easier to read
- Rename `:dev` commands to watch which makes what the commands do clearer