### PR TITLE
chore: set "declaration": false as we're not exporting types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": "./",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "declaration": false
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Not critical per se obviously but works around an issue that otherwise prevents from using PNPM: 
https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189