### PR TITLE
Deterministic Event Handler

### DIFF
--- a/src/indexer/handleEvent.ts
+++ b/src/indexer/handleEvent.ts
@@ -82,36 +82,19 @@ async function handleEvent(
         event.address
       );
 
-      try {
-        await db.collection<Project>("projects").updateOneWhere(
-          (p) => p.projectNumber === event.args.projectID.toNumber(),
-          (project) => ({
-            ...project,
-            metaPtr: event.args.metaPtr.pointer,
-          })
-        );
+      const metadata = await ipfs<Project["metadata"]>(
+        event.args.metaPtr.pointer,
+        indexer.cache
+      );
 
-        return async () => {
-          const metadata = await ipfs<Project["metadata"]>(
-            event.args.metaPtr.pointer,
-            indexer.cache
-          );
-
-          if (!metadata) {
-            return;
-          }
-
-          await db.collection<Project>("projects").updateById(id, (project) => {
-            if (project.metaPtr === event.args.metaPtr.pointer) {
-              return { ...project, metadata };
-            }
-
-            return project;
-          });
+      await db.collection<Project>("projects").updateById(id, (project) => {
+        return {
+          ...project,
+          metaPtr: event.args.metaPtr.pointer,
+          metadata: metadata ?? null,
         };
-      } catch (e) {
-        console.error("Project not found", event.args.projectID.toNumber());
-      }
+      });
+
       break;
     }
 
@@ -436,78 +419,126 @@ async function handleEvent(
 
     // --- Votes
     case "Voted": {
-      return async () => {
-        const voteId = ethers.utils.solidityKeccak256(
-          ["string"],
-          [`${event.blockNumber}-${event.logIndex}`]
-        );
+      const voteId = ethers.utils.solidityKeccak256(
+        ["string"],
+        [`${event.blockNumber}-${event.logIndex}`]
+      );
 
-        const applicationId =
-          event.args.applicationIndex?.toString() ??
-          event.args.projectId.toString();
+      const applicationId =
+        event.args.applicationIndex?.toString() ??
+        event.args.projectId.toString();
 
-        const application = await db
-          .collection<Application>(
-            `rounds/${event.args.roundAddress}/applications`
-          )
-          .findById(applicationId);
+      const application = await db
+        .collection<Application>(
+          `rounds/${event.args.roundAddress}/applications`
+        )
+        .findById(applicationId);
 
-        const round = await db
-          .collection<Round>(`rounds`)
-          .findById(event.args.roundAddress);
+      const round = await db
+        .collection<Round>(`rounds`)
+        .findById(event.args.roundAddress);
 
-        if (
-          application === undefined ||
-          application.status !== "APPROVED" ||
-          round === undefined
-        ) {
-          return;
+      if (
+        application === undefined ||
+        application.status !== "APPROVED" ||
+        round === undefined
+      ) {
+        return;
+      }
+
+      const token = event.args.token.toLowerCase();
+
+      const conversionUSD = await convertToUSD(
+        indexer.chainId,
+        token,
+        event.args.amount.toBigInt(),
+        event.blockNumber
+      );
+
+      const amountUSD = conversionUSD.amount;
+
+      const amountRoundToken =
+        round.token === token
+          ? event.args.amount.toString()
+          : (
+              await convertFromUSD(
+                indexer.chainId,
+                round.token,
+                conversionUSD.amount,
+                event.blockNumber
+              )
+            ).amount.toString();
+
+      const vote = {
+        id: voteId,
+        transaction: event.transactionHash,
+        blockNumber: event.blockNumber,
+        projectId: event.args.projectId,
+        applicationId: applicationId,
+        roundId: event.args.roundAddress,
+        voter: event.args.voter,
+        grantAddress: event.args.grantAddress,
+        token: event.args.token,
+        amount: event.args.amount.toString(),
+        amountUSD: amountUSD,
+        amountRoundToken,
+      };
+
+      // Insert or update  unique round contributor
+      const roundContributors = db.collection<Contributor>(
+        `rounds/${event.args.roundAddress}/contributors`
+      );
+
+      const isNewRoundContributor = await roundContributors.upsertById(
+        event.args.voter,
+        (contributor) => {
+          if (contributor) {
+            return {
+              ...contributor,
+              amountUSD: contributor.amountUSD + amountUSD,
+              votes: contributor.votes + 1,
+            };
+          } else {
+            return {
+              id: event.args.voter,
+              amountUSD,
+              votes: 1,
+            };
+          }
         }
+      );
 
-        const token = event.args.token.toLowerCase();
+      // Insert or update unique project contributor
+      const projectContributors = db.collection<Contributor>(
+        `rounds/${event.args.roundAddress}/projects/${event.args.projectId}/contributors`
+      );
 
-        const conversionUSD = await convertToUSD(
-          indexer.chainId,
-          token,
-          event.args.amount.toBigInt(),
-          event.blockNumber
-        );
+      const isNewProjectContributor = await projectContributors.upsertById(
+        event.args.voter,
+        (contributor) => {
+          if (contributor) {
+            return {
+              ...contributor,
+              amountUSD: contributor.amountUSD + amountUSD,
+              votes: contributor.votes + 1,
+            };
+          } else {
+            return {
+              id: event.args.voter,
+              amountUSD,
+              votes: 1,
+            };
+          }
+        }
+      );
 
-        const amountUSD = conversionUSD.amount;
+      // Insert or update unique application contributor
+      const applicationContributors = db.collection<Contributor>(
+        `rounds/${event.args.roundAddress}/applications/${applicationId}/contributors`
+      );
 
-        const amountRoundToken =
-          round.token === token
-            ? event.args.amount.toString()
-            : (
-                await convertFromUSD(
-                  indexer.chainId,
-                  round.token,
-                  conversionUSD.amount,
-                  event.blockNumber
-                )
-              ).amount.toString();
-
-        const vote = {
-          id: voteId,
-          transaction: event.transactionHash,
-          blockNumber: event.blockNumber,
-          projectId: event.args.projectId,
-          applicationId: applicationId,
-          roundId: event.args.roundAddress,
-          voter: event.args.voter,
-          grantAddress: event.args.grantAddress,
-          token: event.args.token,
-          amount: event.args.amount.toString(),
-          amountUSD: amountUSD,
-          amountRoundToken,
-        };
-
-        // Insert or update  unique round contributor
-        const roundContributors = db.collection<Contributor>(
-          `rounds/${event.args.roundAddress}/contributors`
-        );
-
-        const isNewRoundContributor = await roundContributors.upsertById(
+      const isNewapplicationContributor =
+        await applicationContributors.upsertById(
           event.args.voter,
           (contributor) => {
             if (contributor) {
@@ -526,121 +557,70 @@ async function handleEvent(
           }
         );
 
-        // Insert or update unique project contributor
-        const projectContributors = db.collection<Contributor>(
-          `rounds/${event.args.roundAddress}/projects/${event.args.projectId}/contributors`
-        );
+      await db
+        .collection<Application>(
+          `rounds/${event.args.roundAddress}/applications`
+        )
+        .updateById(applicationId, (project) => ({
+          ...project,
+          amountUSD: project.amountUSD + amountUSD,
+          votes: project.votes + 1,
+          uniqueContributors:
+            project.uniqueContributors + (isNewapplicationContributor ? 1 : 0),
+        }));
 
-        const isNewProjectContributor = await projectContributors.upsertById(
-          event.args.voter,
-          (contributor) => {
-            if (contributor) {
-              return {
-                ...contributor,
-                amountUSD: contributor.amountUSD + amountUSD,
-                votes: contributor.votes + 1,
-              };
-            } else {
-              return {
-                id: event.args.voter,
-                amountUSD,
-                votes: 1,
-              };
-            }
-          }
-        );
+      await db
+        .collection<Vote>(
+          `rounds/${event.args.roundAddress}/applications/${applicationId}/votes`
+        )
+        .insert(vote);
 
-        // Insert or update unique application contributor
-        const applicationContributors = db.collection<Contributor>(
-          `rounds/${event.args.roundAddress}/applications/${applicationId}/contributors`
-        );
+      const contributorPartitionedPath = vote.voter
+        .split(/(.{6})/)
+        .filter((s: string) => s.length > 0)
+        .join("/");
 
-        const isNewapplicationContributor =
-          await applicationContributors.upsertById(
-            event.args.voter,
-            (contributor) => {
-              if (contributor) {
-                return {
-                  ...contributor,
-                  amountUSD: contributor.amountUSD + amountUSD,
-                  votes: contributor.votes + 1,
-                };
-              } else {
-                return {
-                  id: event.args.voter,
-                  amountUSD,
-                  votes: 1,
-                };
-              }
-            }
-          );
-
-        await db
-          .collection<Application>(
-            `rounds/${event.args.roundAddress}/applications`
+      await Promise.all([
+        db
+          .collection<DetailedVote>(
+            `contributors/${contributorPartitionedPath}`
           )
-          .updateById(applicationId, (project) => ({
+          .insert({
+            ...vote,
+            roundName: round.metadata?.name,
+            projectTitle: application.metadata?.application.project.title,
+            roundStartTime: round.roundStartTime,
+            roundEndTime: round.roundEndTime,
+          }),
+        db
+          .collection<Round>("rounds")
+          .updateById(event.args.roundAddress, (round) => ({
+            ...round,
+            amountUSD: round.amountUSD + amountUSD,
+            votes: round.votes + 1,
+            uniqueContributors:
+              round.uniqueContributors + (isNewRoundContributor ? 1 : 0),
+          })),
+        db
+          .collection<Application>(`rounds/${event.args.roundAddress}/projects`)
+          .updateById(event.args.projectId, (project) => ({
             ...project,
             amountUSD: project.amountUSD + amountUSD,
             votes: project.votes + 1,
             uniqueContributors:
-              project.uniqueContributors +
-              (isNewapplicationContributor ? 1 : 0),
-          }));
-
-        await db
+              project.uniqueContributors + (isNewProjectContributor ? 1 : 0),
+          })),
+        db
+          .collection<Vote>(`rounds/${event.args.roundAddress}/votes`)
+          .insert(vote),
+        db
           .collection<Vote>(
-            `rounds/${event.args.roundAddress}/applications/${applicationId}/votes`
+            `rounds/${event.args.roundAddress}/projects/${event.args.projectId}/votes`
           )
-          .insert(vote);
+          .insert(vote),
+      ]);
 
-        const contributorPartitionedPath = vote.voter
-          .split(/(.{6})/)
-          .filter((s: string) => s.length > 0)
-          .join("/");
-
-        await Promise.all([
-          db
-            .collection<DetailedVote>(
-              `contributors/${contributorPartitionedPath}`
-            )
-            .insert({
-              ...vote,
-              roundName: round.metadata?.name,
-              projectTitle: application.metadata?.application.project.title,
-              roundStartTime: round.roundStartTime,
-              roundEndTime: round.roundEndTime,
-            }),
-          db
-            .collection<Round>("rounds")
-            .updateById(event.args.roundAddress, (round) => ({
-              ...round,
-              amountUSD: round.amountUSD + amountUSD,
-              votes: round.votes + 1,
-              uniqueContributors:
-                round.uniqueContributors + (isNewRoundContributor ? 1 : 0),
-            })),
-          db
-            .collection<Application>(
-              `rounds/${event.args.roundAddress}/projects`
-            )
-            .updateById(event.args.projectId, (project) => ({
-              ...project,
-              amountUSD: project.amountUSD + amountUSD,
-              votes: project.votes + 1,
-              uniqueContributors:
-                project.uniqueContributors + (isNewProjectContributor ? 1 : 0),
-            })),
-          db
-            .collection<Vote>(`rounds/${event.args.roundAddress}/votes`)
-            .insert(vote),
-          db
-            .collection<Vote>(
-              `rounds/${event.args.roundAddress}/projects/${event.args.projectId}/votes`
-            )
-            .insert(vote),
-        ]);
-      };
+      break;
     }
 
     default:

--- a/src/indexer/handlers/applicationMetaPtrUpdated.ts
+++ b/src/indexer/handlers/applicationMetaPtrUpdated.ts
@@ -9,28 +9,15 @@ export default async function applicationMetaPtrUpdated(
 ) {
   const id = event.address;
 
-  const args = event.args as {
-    newMetaPtr: { pointer: string };
-  };
-
-  await db.collection<Round>("rounds").updateById(id, (round) => ({
-    ...round,
-    applicationMetaPtr: args.newMetaPtr.pointer,
-    updatedAtBlock: event.blockNumber,
-  }));
-
-  const metaPtr = args.newMetaPtr.pointer;
+  const metaPtr = event.args.newMetaPtr.pointer;
   const metadata = await ipfs<Round["applicationMetadata"]>(metaPtr, cache);
 
-  if (!metadata) {
-    return;
-  }
-
   await db.collection<Round>("rounds").updateById(id, (round) => {
-    if (round.applicationMetaPtr === args.newMetaPtr.pointer) {
-      return { ...round, applicationMetadata: metadata };
-    }
-
-    return round;
+    return {
+      ...round,
+      applicationMetaPtr: event.args.newMetaPtr.pointer,
+      updatedAtBlock: event.blockNumber,
+      applicationMetadata: metadata ?? null,
+    };
   });
 }

--- a/src/indexer/handlers/roundMetaPtrUpdated.ts
+++ b/src/indexer/handlers/roundMetaPtrUpdated.ts
@@ -9,23 +9,14 @@ export default async function roundMetaPtrUpdated(
 ) {
   const id = event.address;
 
-  await db.collection<Round>("rounds").updateById(id, (round) => ({
-    ...round,
-    metaPtr: event.args.newMetaPtr.pointer,
-  }));
-
   const metaPtr = event.args.newMetaPtr.pointer;
   const metadata = await ipfs<Round["metadata"]>(metaPtr, cache);
 
-  if (!metadata) {
-    return;
-  }
-
   await db.collection<Round>("rounds").updateById(id, (round) => {
-    if (round.metaPtr === event.args.newMetaPtr.pointer) {
-      return { ...round, metadata };
-    }
-
-    return round;
+    return {
+      ...round,
+      metadata: metadata ?? null,
+      metaPtr: event.args.newMetaPtr.pointer,
+    };
   });
 }


### PR DESCRIPTION
This deletes thunks so that events are always processed sequentially, this should always yield the same result with consequent runs.

```bash
$ npm run index -- --chain=mainnet --clear
$ mv data/1 snapshot_1
$ npm run index -- --chain=mainnet --clear
$ diff --brief -r snapshot_1 data/1
Files snapshot_1/_subscriptions.json and data/1/_subscriptions.json differ
Files snapshot_1/prices.json and data/1/prices.json differ
```

Subscriptions and prices are different, that is expected.

There's a small behaviour change from main (happy to put this in a separate PR):

- If the metadata pointer is invalid, we still update the `metaPtr` but we reset the metadata to `null`, instead of keeping the old metadata, which could be confusing.
