### PR TITLE
Foreign chain price retrieval

### DIFF
--- a/src/cli/indexer.ts
+++ b/src/cli/indexer.ts
@@ -6,79 +6,87 @@ import {
   Indexer,
   Event as ChainsauceEvent,
 } from "chainsauce";
-import { fetchJsonCached as ipfs } from "../utils/ipfs.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 
 import "../sentry.js";
 import handleEvent from "../indexer/handleEvent.js";
-import { getIndexerConfig } from "../config.js";
+import { getIndexerConfig, IndexerConfig } from "../config.js";
 import { createPriceProvider, createPriceUpdater } from "../prices/index.js";
 import { importAbi } from "../indexer/utils.js";
+import { fetchJsonCached } from "../utils/ipfs.js";
 
-const config = getIndexerConfig();
-
-if (config.clear) {
-  console.info("Clearing storage directory.");
-  try {
-    await fs.rm(config.storageDir, { recursive: true });
-  } catch {
-    console.info("No storage to clear.");
+async function main(config: IndexerConfig) {
+  if (config.clear) {
+    console.info("Clearing storage directory.");
+    try {
+      await fs.rm(config.storageDir, { recursive: true });
+    } catch {
+      console.info("No storage to clear.");
+    }
   }
-}
 
-const rpcProvider = new RetryProvider({
-  url: config.chain.rpc,
-  timeout: 5 * 60 * 1000,
-});
+  // Dependencies
 
-await rpcProvider.getNetwork();
+  const priceProvider = createPriceProvider(config);
 
-// Update prices to present and optionally keep watching for updates
+  const rpcProvider = new RetryProvider({
+    url: config.chain.rpc,
+    timeout: 5 * 60 * 1000,
+  });
 
-const priceUpdater = createPriceUpdater({
-  rpcProvider,
-  cache: config.cacheDir
-    ? new Cache(path.join(config.cacheDir, "prices"))
-    : null,
-  chain: config.chain,
-});
+  await rpcProvider.getNetwork();
 
-if (config.follow) {
-  await priceUpdater.catchupAndWatch();
-} else {
-  await priceUpdater.fetchPricesUntilBlock(config.toBlock ?? "latest");
-}
+  // Update prices to present and optionally keep watching for updates
 
-// Process blockchain events
-
-const priceProvider = createPriceProvider({});
-
-const indexer = await createIndexer(
-  rpcProvider,
-  new JsonStorage(path.join(config.storageDir, config.chain.id.toString())),
-  (indexer: Indexer<JsonStorage>, event: ChainsauceEvent) => {
-    return handleEvent(event, {
-      db: indexer.storage,
-      indexer,
-      ipfs,
-      priceProvider,
-    });
-  },
-  {
-    toBlock: config.toBlock,
-    logLevel: config.logLevel,
-    eventCacheDirectory: config.cacheDir
-      ? path.join(config.cacheDir, "events")
+  const priceUpdater = createPriceUpdater({
+    ...config,
+    rpcProvider,
+    cache: config.cacheDir
+      ? new Cache(path.join(config.cacheDir, "prices"))
       : null,
-    runOnce: !config.follow,
-  }
-);
+    chain: config.chain,
+  });
 
-for (const subscription of config.chain.subscriptions) {
-  indexer.subscribe(
-    subscription.address,
-    await importAbi(subscription.abi),
-    Math.max(subscription.fromBlock || 0, config.fromBlock)
+  if (config.follow) {
+    await priceUpdater.catchupAndWatch();
+  } else {
+    await priceUpdater.fetchPricesUntilBlock(config.toBlock ?? "latest");
+  }
+
+  // Update blockchain-dependent state to present and optionally keep watching for updates
+
+  const indexer = await createIndexer(
+    rpcProvider,
+    new JsonStorage(path.join(config.storageDir, config.chain.id.toString())),
+    (indexer: Indexer<JsonStorage>, event: ChainsauceEvent) => {
+      return handleEvent(event, {
+        db: indexer.storage,
+        indexer,
+        ipfs: (cid: string) =>
+          fetchJsonCached(cid, indexer.cache, {
+            ipfsGateway: config.ipfsGateway,
+          }),
+        priceProvider,
+      });
+    },
+    {
+      toBlock: config.toBlock,
+      logLevel: config.logLevel,
+      eventCacheDirectory: config.cacheDir
+        ? path.join(config.cacheDir, "events")
+        : null,
+      runOnce: !config.follow,
+    }
   );
+
+  for (const subscription of config.chain.subscriptions) {
+    indexer.subscribe(
+      subscription.address,
+      await importAbi(subscription.abi),
+      Math.max(subscription.fromBlock || 0, config.fromBlock)
+    );
+  }
 }
+
+await main(getIndexerConfig());

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,27 +77,21 @@ export const chains: Chain[] = [
     tokens: [
       {
         code: "USDC",
-        address: "0xd35CCeEAD182dcee0F148EbaC9447DA2c4D449c4",
+        address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         decimals: 6,
-        chainId: 5,
+        chainId: 1,
       },
       {
         code: "DAI",
-        address: "0x73967c6a0904aA032C103b4104747E88c566B1A2",
+        address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         decimals: 18,
-        chainId: 5,
-      },
-      {
-        code: "DAI",
-        address: "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
-        decimals: 18,
-        chainId: 5,
+        chainId: 1,
       },
       {
         code: "ETH",
         address: "0x0000000000000000000000000000000000000000",
         decimals: 18,
-        chainId: 5,
+        chainId: 1,
       },
     ],
     subscriptions: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,17 +6,26 @@ import path from "node:path";
 
 type ChainId = number;
 
+export type Token = {
+  code: string;
+  address: string;
+  decimals: number;
+  chainId: ChainId;
+};
+
+export type Subscription = {
+  address: string;
+  abi: string;
+  fromBlock?: number;
+  events?: Record<string, string>;
+};
+
 export type Chain = {
   rpc: string;
   name: string;
   id: ChainId;
-  tokens: { code: string; address: string; decimals: number }[];
-  subscriptions: {
-    address: string;
-    abi: string;
-    fromBlock?: number;
-    events?: Record<string, string>;
-  }[];
+  tokens: Token[];
+  subscriptions: Subscription[];
 };
 
 export const chains: Chain[] = [
@@ -29,16 +38,19 @@ export const chains: Chain[] = [
         code: "USDC",
         address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         decimals: 6,
+        chainId: 1,
       },
       {
         code: "DAI",
         address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         decimals: 18,
+        chainId: 1,
       },
       {
         code: "ETH",
         address: "0x0000000000000000000000000000000000000000",
         decimals: 18,
+        chainId: 1,
       },
     ],
     subscriptions: [
@@ -67,21 +79,25 @@ export const chains: Chain[] = [
         code: "USDC",
         address: "0xd35CCeEAD182dcee0F148EbaC9447DA2c4D449c4",
         decimals: 6,
+        chainId: 5,
       },
       {
         code: "DAI",
         address: "0x73967c6a0904aA032C103b4104747E88c566B1A2",
         decimals: 18,
+        chainId: 5,
       },
       {
         code: "DAI",
         address: "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
         decimals: 18,
+        chainId: 5,
       },
       {
         code: "ETH",
         address: "0x0000000000000000000000000000000000000000",
         decimals: 18,
+        chainId: 5,
       },
     ],
     subscriptions: [
@@ -124,16 +140,19 @@ export const chains: Chain[] = [
         code: "USDC",
         address: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
         decimals: 6,
+        chainId: 10,
       },
       {
         code: "DAI",
         address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
         decimals: 18,
+        chainId: 10,
       },
       {
         code: "ETH",
         address: "0x0000000000000000000000000000000000000000",
         decimals: 18,
+        chainId: 10,
       },
     ],
     subscriptions: [
@@ -162,16 +181,19 @@ export const chains: Chain[] = [
         code: "USDC",
         address: "0x04068DA6C83AFCFA0e13ba15A6696662335D5B75",
         decimals: 6,
+        chainId: 250,
       },
       {
         code: "DAI",
         address: "0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E",
         decimals: 18,
+        chainId: 250,
       },
       {
         code: "FTM",
         address: "0x0000000000000000000000000000000000000000",
         decimals: 18,
+        chainId: 250,
       },
     ],
     subscriptions: [
@@ -203,11 +225,13 @@ export const chains: Chain[] = [
         code: "DAI",
         address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
         decimals: 18,
+        chainId: 58008,
       },
       {
         code: "ETH",
         address: "0x0000000000000000000000000000000000000000",
         decimals: 18,
+        chainId: 58008,
       },
     ],
     subscriptions: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,15 +223,15 @@ export const chains: Chain[] = [
     tokens: [
       {
         code: "DAI",
-        address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         decimals: 18,
-        chainId: 58008,
+        chainId: 1,
       },
       {
         code: "ETH",
         address: "0x0000000000000000000000000000000000000000",
         decimals: 18,
-        chainId: 58008,
+        chainId: 1,
       },
     ],
     subscriptions: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -379,7 +379,11 @@ export function getIndexerConfig(): IndexerConfig {
     throw new Error("Chain " + chainName + " is not configured");
   }
   const toBlock =
-    "to-block" in args ? Number(args["to-block"]) : ("latest" as const);
+    "to-block" in args
+      ? args["to-block"] === "latest"
+        ? ("latest" as const)
+        : Number(args["to-block"])
+      : ("latest" as const);
   const fromBlock = "from-block" in args ? Number(args["from-block"]) : 0;
 
   const provider = new RetryProvider({

--- a/src/http/api/v1/exports.ts
+++ b/src/http/api/v1/exports.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 import path from "path";
 
 import database from "../../../database.js";
-import { getPrices } from "../../../prices/index.js";
+import { createPriceProvider } from "../../../prices/index.js";
 import { Round, Application, Vote } from "../../../indexer/types.js";
 import { getVotesWithCoefficients } from "../../../calculator/votes.js";
 import ClientError from "../clientError.js";
@@ -48,7 +48,11 @@ async function exportVotesCSV(db: JsonStorage, round: Round) {
 }
 
 async function exportPricesCSV(chainId: number, round: Round) {
-  const prices = await getPrices(chainId);
+  const priceProvider = createPriceProvider({
+    storageDir: config.storageDir,
+  });
+
+  const prices = await priceProvider.getAllPricesForChain(chainId);
 
   const pricesDuringRound = prices.filter(
     (price) =>

--- a/src/http/api/v1/matches.ts
+++ b/src/http/api/v1/matches.ts
@@ -23,7 +23,7 @@ export const calculatorConfig: {
   dataProvider: DataProvider;
   priceProvider: PriceProvider;
 } = {
-  priceProvider: createPriceProvider({}),
+  priceProvider: createPriceProvider({ storageDir: "dummy" }),
   dataProvider: new FileSystemDataProvider(config.storageDir),
 };
 

--- a/src/indexer/handlers/applicationMetaPtrUpdated.ts
+++ b/src/indexer/handlers/applicationMetaPtrUpdated.ts
@@ -1,16 +1,16 @@
 import { Indexer, JsonStorage } from "chainsauce";
-import { fetchJsonCached as ipfs } from "../../utils/ipfs.js";
 import { Round } from "../types.js";
 import { ApplicationMetaPtrUpdatedEvent } from "../events.js";
 
 export default async function applicationMetaPtrUpdated(
-  { cache, storage: db }: Indexer<JsonStorage>,
-  event: ApplicationMetaPtrUpdatedEvent
+  { storage: db }: Indexer<JsonStorage>,
+  event: ApplicationMetaPtrUpdatedEvent,
+  ipfs: <T>(cid: string) => Promise<T | undefined>
 ) {
   const id = event.address;
 
   const metaPtr = event.args.newMetaPtr.pointer;
-  const metadata = await ipfs<Round["applicationMetadata"]>(metaPtr, cache);
+  const metadata = await ipfs<Round["applicationMetadata"]>(metaPtr);
 
   await db.collection<Round>("rounds").updateById(id, (round) => {
     return {

--- a/src/indexer/handlers/roundMetaPtrUpdated.ts
+++ b/src/indexer/handlers/roundMetaPtrUpdated.ts
@@ -1,16 +1,16 @@
 import { Indexer, JsonStorage } from "chainsauce";
-import { fetchJsonCached as ipfs } from "../../utils/ipfs.js";
 import { Round } from "../types.js";
 import { RoundMetaPtrUpdatedEvent } from "../events.js";
 
 export default async function roundMetaPtrUpdated(
-  { cache, storage: db }: Indexer<JsonStorage>,
-  event: RoundMetaPtrUpdatedEvent
+  { storage: db }: Indexer<JsonStorage>,
+  event: RoundMetaPtrUpdatedEvent,
+  ipfs: <T>(cid: string) => Promise<T | undefined>
 ) {
   const id = event.address;
 
   const metaPtr = event.args.newMetaPtr.pointer;
-  const metadata = await ipfs<Round["metadata"]>(metaPtr, cache);
+  const metadata = await ipfs<Round["metadata"]>(metaPtr);
 
   await db.collection<Round>("rounds").updateById(id, (round) => {
     return {

--- a/src/prices/coinGecko.ts
+++ b/src/prices/coinGecko.ts
@@ -51,10 +51,6 @@ async function fetchPrices(
   endTime: UnixTimestamp,
   config: { coingeckoApiKey: string | null; coingeckoApiUrl: string }
 ): Promise<[Timestamp, Price][]> {
-  if (token.chainId === 5) {
-    return [];
-  }
-
   const platform = platforms[token.chainId];
   const nativeToken = nativeTokens[token.chainId];
 

--- a/src/prices/coinGecko.ts
+++ b/src/prices/coinGecko.ts
@@ -51,7 +51,7 @@ async function fetchPrices(
   endTime: UnixTimestamp,
   config: { coingeckoApiKey: string | null; coingeckoApiUrl: string }
 ): Promise<[Timestamp, Price][]> {
-  if (token.chainId === 5 || token.chainId === 58008) {
+  if (token.chainId === 5) {
     return [];
   }
 

--- a/src/prices/index.ts
+++ b/src/prices/index.ts
@@ -336,20 +336,6 @@ export function createPriceProvider(
   ): Promise<Price & { decimals: number }> {
     let closestPrice: Price | null = null;
 
-    if (
-      // goerli
-      chainId === 5
-    ) {
-      return {
-        token,
-        code: "ETH",
-        price: 1,
-        timestamp: 0,
-        block: 0,
-        decimals: 18,
-      };
-    }
-
     if (!tokenDecimals[chainId][token]) {
       console.error(`Unsupported token ${token} for chain ${chainId}`);
       return {

--- a/src/prices/index.ts
+++ b/src/prices/index.ts
@@ -6,10 +6,7 @@ import { ethers } from "ethers";
 import { getBlockFromTimestamp } from "../utils/getBlockFromTimestamp.js";
 import { getPricesByHour } from "./coinGecko.js";
 import { existsSync } from "fs";
-import { Chain, tokenDecimals, getPricesConfig } from "../config.js";
-
-// XXX needs to be a function parameter, not a module variable
-const config = getPricesConfig();
+import { Chain, tokenDecimals } from "../config.js";
 
 export type Price = {
   token: string;
@@ -38,151 +35,6 @@ function chunkTimeBy(millis: number, chunkBy: number): [number, number][] {
   return chunks;
 }
 
-async function updatePricesAndWrite(
-  provider: ethers.providers.JsonRpcProvider,
-  cache: Cache | null,
-  chain: Chain,
-  toBlock: number | "latest" = "latest"
-) {
-  const currentPrices = await getPrices(chain.id);
-
-  // get last updated price
-  const lastPriceAt = currentPrices.reduce(
-    (acc, price) => Math.max(price.timestamp + hours(1), acc),
-    EARLIEST_PRICE_TIMESTAMP
-  );
-
-  let toDate = undefined;
-
-  if (toBlock === "latest") {
-    toDate = new Date();
-  } else {
-    const block = await provider.getBlock(toBlock);
-    toDate = new Date(block.timestamp * 1000);
-  }
-
-  // time elapsed from the last update, rounded to hours
-  const timeElapsed =
-    Math.floor((toDate.getTime() - lastPriceAt) / hours(1)) * hours(1);
-
-  // only fetch new prices every new hour
-  if (timeElapsed < hours(1)) {
-    return;
-  }
-
-  const getCacheLazy = async <T>(cacheKey: string, fn: () => Promise<T>) => {
-    if (cache) {
-      return await cache.lazy(cacheKey, fn);
-    } else {
-      return await fn();
-    }
-  };
-
-  const getBlockTimestamp = async (blockNumber: number) => {
-    const block = await getCacheLazy(
-      `block-${chain.id}-${blockNumber}`,
-      async () => {
-        return await provider.getBlock(blockNumber);
-      }
-    );
-
-    return block.timestamp;
-  };
-
-  const lastBlockNumber = await provider.getBlockNumber();
-
-  // get prices in 90 day chunks to get the most of Coingecko's granularity
-  const timeChunks = chunkTimeBy(timeElapsed, days(90));
-
-  for (const chunk of timeChunks) {
-    for (const token of chain.tokens) {
-      const cacheKey = `${chain.id}-${token.address}-${
-        lastPriceAt + chunk[0]
-      }-${lastPriceAt + chunk[1]}`;
-
-      console.log(
-        "Fetching prices for",
-        token.code,
-        ":",
-        new Date(lastPriceAt + chunk[0]),
-        "-",
-        new Date(lastPriceAt + chunk[1])
-      );
-
-      const prices = await getCacheLazy(cacheKey, () =>
-        getPricesByHour(
-          token,
-          (lastPriceAt + chunk[0]) / 1000,
-          (lastPriceAt + chunk[1]) / 1000
-        )
-      );
-
-      const newPrices: Price[] = [];
-
-      for (const [timestamp, price] of prices) {
-        const blockNumber = await getBlockFromTimestamp(
-          timestamp,
-          0,
-          lastBlockNumber,
-          getBlockTimestamp
-        );
-
-        if (blockNumber === undefined) {
-          throw new Error(
-            `Could not find block number for timestamp: ${timestamp}`
-          );
-        }
-
-        newPrices.push({
-          token: token.address.toLowerCase(),
-          code: token.code,
-          price,
-          timestamp,
-          block: blockNumber,
-        });
-      }
-
-      console.log("Fetched", newPrices.length, "new prices");
-
-      await appendPrices(chain.id, newPrices);
-    }
-  }
-}
-
-export async function getPrices(chainId: number): Promise<Price[]> {
-  return readPricesFile(chainId);
-}
-
-async function appendPrices(chainId: number, newPrices: Price[]) {
-  const currentPrices = await getPrices(chainId);
-  await writePrices(chainId, currentPrices.concat(newPrices));
-}
-
-function pricesFilename(chainId: number): string {
-  return path.join(config.storageDir, `${chainId}/prices.json`);
-}
-
-async function readPricesFile(chainId: number): Promise<Price[]> {
-  const filename = pricesFilename(chainId);
-
-  if (existsSync(filename)) {
-    return JSON.parse((await fs.readFile(filename)).toString()) as Price[];
-  }
-
-  return [];
-}
-
-async function writePrices(chainId: number, prices: Price[]) {
-  return writePricesFile(pricesFilename(chainId), prices);
-}
-
-async function writePricesFile(filename: string, prices: Price[]) {
-  const tempFile = `${filename}.write`;
-  await fs.mkdir(path.dirname(filename), { recursive: true });
-  await fs.writeFile(tempFile, JSON.stringify(prices));
-  await fs.rename(tempFile, filename);
-}
-
 export interface PriceUpdaterService {
   catchupAndWatch: () => Promise<void>;
   fetchPricesUntilBlock: (toBlock: ToBlock) => Promise<void>;
@@ -192,11 +44,16 @@ interface PriceUpdaterConfig {
   rpcProvider: ethers.providers.StaticJsonRpcProvider;
   cache: Cache | null;
   chain: Chain;
+  storageDir: string;
+  coingeckoApiKey: string | null;
+  coingeckoApiUrl: string;
 }
 
 export function createPriceUpdater(
   config: PriceUpdaterConfig
 ): PriceUpdaterService {
+  // PUBLIC
+
   async function catchupAndWatch() {
     await fetchPricesUntilBlock("latest");
 
@@ -212,6 +69,8 @@ export function createPriceUpdater(
     );
   }
 
+  // INTERNALS
+
   function watchLoop() {
     updatePricesAndWrite(config.rpcProvider, config.cache, config.chain)
       .then(() => {
@@ -219,6 +78,136 @@ export function createPriceUpdater(
       })
       .catch((err) => console.error(err));
   }
+
+  async function updatePricesAndWrite(
+    provider: ethers.providers.JsonRpcProvider,
+    cache: Cache | null,
+    chain: Chain,
+    toBlock: number | "latest" = "latest"
+  ) {
+    const currentPrices = await readPricesFile(chain.id, config.storageDir);
+
+    // get last updated price
+    const lastPriceAt = currentPrices.reduce(
+      (acc, price) => Math.max(price.timestamp + hours(1), acc),
+      EARLIEST_PRICE_TIMESTAMP
+    );
+
+    let toDate = undefined;
+
+    if (toBlock === "latest") {
+      toDate = new Date();
+    } else {
+      const block = await provider.getBlock(toBlock);
+      toDate = new Date(block.timestamp * 1000);
+    }
+
+    // time elapsed from the last update, rounded to hours
+    const timeElapsed =
+      Math.floor((toDate.getTime() - lastPriceAt) / hours(1)) * hours(1);
+
+    // only fetch new prices every new hour
+    if (timeElapsed < hours(1)) {
+      return;
+    }
+
+    const getCacheLazy = async <T>(cacheKey: string, fn: () => Promise<T>) => {
+      if (cache) {
+        return await cache.lazy(cacheKey, fn);
+      } else {
+        return await fn();
+      }
+    };
+
+    const getBlockTimestamp = async (blockNumber: number) => {
+      const block = await getCacheLazy(
+        `block-${chain.id}-${blockNumber}`,
+        async () => {
+          return await provider.getBlock(blockNumber);
+        }
+      );
+
+      return block.timestamp;
+    };
+
+    const lastBlockNumber = await provider.getBlockNumber();
+
+    // get prices in 90 day chunks to get the most of Coingecko's granularity
+    const timeChunks = chunkTimeBy(timeElapsed, days(90));
+
+    for (const chunk of timeChunks) {
+      for (const token of chain.tokens) {
+        const cacheKey = `${chain.id}-${token.address}-${
+          lastPriceAt + chunk[0]
+        }-${lastPriceAt + chunk[1]}`;
+
+        console.log(
+          "Fetching prices for",
+          token.code,
+          ":",
+          new Date(lastPriceAt + chunk[0]),
+          "-",
+          new Date(lastPriceAt + chunk[1])
+        );
+
+        const prices = await getCacheLazy(cacheKey, () =>
+          getPricesByHour(
+            token,
+            (lastPriceAt + chunk[0]) / 1000,
+            (lastPriceAt + chunk[1]) / 1000,
+            config
+          )
+        );
+
+        const newPrices: Price[] = [];
+
+        for (const [timestamp, price] of prices) {
+          const blockNumber = await getBlockFromTimestamp(
+            timestamp,
+            0,
+            lastBlockNumber,
+            getBlockTimestamp
+          );
+
+          if (blockNumber === undefined) {
+            throw new Error(
+              `Could not find block number for timestamp: ${timestamp}`
+            );
+          }
+
+          newPrices.push({
+            token: token.address.toLowerCase(),
+            code: token.code,
+            price,
+            timestamp,
+            block: blockNumber,
+          });
+        }
+
+        console.log("Fetched", newPrices.length, "new prices");
+
+        await appendPrices(chain.id, newPrices);
+      }
+    }
+  }
+
+  async function appendPrices(chainId: number, newPrices: Price[]) {
+    const currentPrices = await readPricesFile(chainId, config.storageDir);
+    await writePrices(chainId, currentPrices.concat(newPrices));
+  }
+
+  async function writePrices(chainId: number, prices: Price[]) {
+    return writePricesFile(pricesFilename(chainId, config.storageDir), prices);
+  }
+
+  async function writePricesFile(filename: string, prices: Price[]) {
+    const tempFile = `${filename}.write`;
+    await fs.mkdir(path.dirname(filename), { recursive: true });
+    await fs.writeFile(tempFile, JSON.stringify(prices));
+    await fs.rename(tempFile, filename);
+  }
+
+  // API
 
   return {
     catchupAndWatch,
@@ -228,6 +217,7 @@ export function createPriceUpdater(
 
 interface PriceProviderConfig {
   updateEvery?: number; // XXX hint at time type: secs? msecs?
+  storageDir: string;
 }
 
 export interface PriceProvider {
@@ -243,14 +233,25 @@ export interface PriceProvider {
     amount: number,
     blockNumber: number
   ) => Promise<{ amount: bigint; price: number }>;
+  getAllPricesForChain: (chainId: number) => Promise<Price[]>;
 }
 
 export function createPriceProvider(
   config: PriceProviderConfig
 ): PriceProvider {
+  // STATE
+
   type Prices = { lastUpdatedAt: Date; prices: Promise<Price[]> };
 
   const prices: { [key: number]: Prices } = {};
+
+  // PUBLIC
+
+  async function getAllPricesForChain(chainId: number): Promise<Price[]> {
+    return readPricesFile(chainId, config.storageDir);
+  }
+
+  // INTERNALS
 
   function shouldRefreshPrices(prices: Prices) {
     return (
@@ -260,7 +261,7 @@ export function createPriceProvider(
   }
 
   function updatePrices(chainId: number) {
-    const chainPrices = readPricesFile(chainId);
+    const chainPrices = readPricesFile(chainId, config.storageDir);
 
     prices[chainId] = {
       prices: chainPrices,
@@ -386,5 +387,23 @@ export function createPriceProvider(
   return {
     convertToUSD,
     convertFromUSD,
+    getAllPricesForChain,
   };
+}
+
+async function readPricesFile(
+  chainId: number,
+  storageDir: string
+): Promise<Price[]> {
+  const filename = pricesFilename(chainId, storageDir);
+
+  if (existsSync(filename)) {
+    return JSON.parse((await fs.readFile(filename)).toString()) as Price[];
+  }
+
+  return [];
+}
+
+function pricesFilename(chainId: number, storageDir: string): string {
+  return path.join(storageDir, `${chainId}/prices.json`);
 }

--- a/src/prices/index.ts
+++ b/src/prices/index.ts
@@ -338,9 +338,7 @@ export function createPriceProvider(
 
     if (
       // goerli
-      chainId === 5 ||
-      // pgn-testnet
-      chainId === 58008
+      chainId === 5
     ) {
       return {
         token,

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,23 +1,23 @@
 import { Cache } from "chainsauce";
 
 import fetchRetry from "./fetchRetry.js";
-import { getIndexerConfig } from "../config.js";
-
-// XXX needs to be a function parameter, not a module variable
-const config = getIndexerConfig();
 
 export async function fetchJsonCached<T>(
   cid: string,
-  cache: Cache
+  cache: Cache,
+  config: { ipfsGateway: string }
 ): Promise<T | undefined> {
   return await cache.lazy<T | undefined>(`ipfs-${cid}`, () =>
-    fetchJson<T>(cid)
+    fetchJson<T>(cid, config)
   );
 }
 
 const cidRegex = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[0-9A-Za-z]{50,})$/;
 
-export async function fetchJson<T>(cid: string): Promise<T | undefined> {
+export async function fetchJson<T>(
+  cid: string,
+  config: { ipfsGateway: string }
+): Promise<T | undefined> {
   if (!cidRegex.test(cid)) {
     console.error("Invalid IPFS CID:", cid);
     return undefined;


### PR DESCRIPTION
Allow associating to chain X prices of token on chain Y. Useful when CoinGecko isn't aware of a chain (e.g. PGN) and for testing purposes. 

For PGN testnet, retrieve DAI and ETH prices as on mainnet. Closes #135.

Additional refactors:
- remove many module-scope side effects
- provide ipfs client to `handleEvent` via injection
- consolidate config for price updater and chain-data updater
- unexport many functions not used outside of module


