### PR TITLE
poc: simple unit test example

### DIFF
--- a/src/indexer/handlers/roundMetaPtrUpdated.test.ts
+++ b/src/indexer/handlers/roundMetaPtrUpdated.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, vitest } from "vitest";
+import { default as roundMetaPtrUpdated } from "./roundMetaPtrUpdated.js";
+
+describe("roundMetaPtrUpdated", () => {
+  test("reads metadata from ipfs and updates local database", async () => {
+    const data = {
+      rounds: [
+        {
+          id: "rnd-abc",
+          amountUSD: 123,
+          votes: 1,
+          metaPtr: "oldMetaPtr123",
+          metadata: {
+            name: "FooRound",
+          },
+        },
+      ],
+    };
+    const mockDb = {
+      collection(collectionName: string) {
+        return {
+          updateById(id: string, updateFn: (oldData: any) => any) {
+            const collection = data[collectionName];
+            const recordIndex = collection.findIndex((c) => c.id === id);
+            const oldData = collection[recordIndex];
+            collection[recordIndex] = updateFn(oldData);
+          },
+        };
+      },
+    };
+    const mockIpfsGet = vitest.fn().mockResolvedValue({
+      name: "BarRound",
+    });
+
+    const metaPtr = "newMetaPtr123";
+    await roundMetaPtrUpdated(
+      {
+        name: "RoundMetaPtrUpdated",
+        address: "rnd-abc",
+        args: {
+          newMetaPtr: { pointer: metaPtr },
+        },
+      },
+      { db: mockDb, ipfsGet: mockIpfsGet }
+    );
+
+    expect(mockIpfsGet).toHaveBeenCalledWith(metaPtr);
+    expect(data).toEqual({
+      rounds: [
+        {
+          id: "rnd-abc",
+          amountUSD: 123,
+          votes: 1,
+          metaPtr: "newMetaPtr123",
+          metadata: {
+            name: "BarRound",
+          },
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Not for merging.

This shows a (working) unit test for the simplest event handler I could find. It relies on all the dependency extraction done in the past weeks.

I don't think the approach of mocking "just enough" of the db object is scalable to more complex event handlers. 

An alternative would be to patch chainsauce so that it accepts a `node:fs` implementation, and use [memfs](https://www.npmjs.com/package/memfs) during tests. 

Or store to SQL, as Mo already wanted to do, which can then be tested using sqlite in-memory database, and which would involve writing an adapter: https://github.com/chainsauce-org/chainsauce/blob/6fcec0e98eb508953a829dab1e6fca636cc728de/src/storage/json.ts

Opinions?