### PR TITLE
ops: add development environment on fly

### DIFF
--- a/fly.development.toml
+++ b/fly.development.toml
@@ -1,0 +1,52 @@
+app = "indexer-development"
+primary_region = "den"
+kill_signal = "SIGINT"
+kill_timeout = 5
+
+[experimental]
+  auto_rollback = true
+
+[env]
+  PORT = "8080"
+  DEPLOYMENT_ENVIRONMENT = "development"
+  LOG_LEVEL = "debug"
+  STORAGE_DIR = "/mnt/indexer/data"
+  CACHE_DIR = "/mnt/indexer/cache"
+
+[processes]
+  web = "npm start"
+
+[mounts]
+  source="indexer_development"
+  destination="/mnt/indexer"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8080
+  processes = ["web"]
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+    
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+    
+  [[services.tcp_checks]]
+    interval = "30s"
+    timeout = "10s"
+    grace_period = "1m"
+    
+  [[services.http_checks]]
+    interval = "60s"
+    grace_period = "1m"
+    timeout = "5s"
+    method = "get"
+    path = "/data/"
+    protocol = "http"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write src",
     "test": "vitest run --reporter verbose",
     "test:watch": "vitest watch --reporter verbose",
-    "deploy:staging": "docker buildx build . -t registry.fly.io/indexer-staging:latest && docker push registry.fly.io/indexer-staging:latest && flyctl -c fly.staging.toml --app indexer-staging deploy -i registry.fly.io/indexer-staging:latest" 
+    "deploy:development": "docker buildx build . -t registry.fly.io/indexer-development:latest && docker push registry.fly.io/indexer-development:latest && flyctl -c fly.development.toml --app indexer-development deploy -i registry.fly.io/indexer-development:latest"
   },
   "imports": {
     "#abis/*": {


### PR DESCRIPTION
Closes #179 

Once this is merged:

- pushing to the `main` branch continues to deploy to `indexer-staging.fly.dev`
- pushing to the `release` branch continues to deploy to `indexer-production.fly.dev`
- running `npm run deploy:development` locally will deploy to `indexer-development.fly.dev`

We could create another branch to trigger the last deployment but really the energy would be better spent on good regression testing so we don't need that environment at all.