### PR TITLE
fix: ensure initial catchup is done before starting http api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2619,7 +2619,7 @@
     },
     "node_modules/chainsauce": {
       "version": "1.0.19",
-      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#1e671958c8dabca469a6760c7ec28347c22ba535",
+      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#b32ff3eeee5a7738aace591455ed73b35dfa8b8b",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.2.0",
@@ -8626,7 +8626,7 @@
       }
     },
     "chainsauce": {
-      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#1e671958c8dabca469a6760c7ec28347c22ba535",
+      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#b32ff3eeee5a7738aace591455ed73b35dfa8b8b",
       "from": "chainsauce@github:gitcoinco/chainsauce",
       "requires": {
         "better-sqlite3": "^8.2.0",

--- a/src/utils/asyncSentinel.ts
+++ b/src/utils/asyncSentinel.ts
@@ -1,0 +1,32 @@
+// A utility class necessary because promise state is not inspectable, otherwise
+// plain promise could be used.
+
+export class AsyncSentinel {
+  _promise: Promise<void>;
+  _resolve: null | (() => void) = null;
+  _isDone: boolean = false;
+
+  constructor() {
+    this._promise = new Promise((resolve) => {
+      this._resolve = resolve;
+    });
+  }
+
+  untilDone() {
+    return this._promise;
+  }
+
+  isDone() {
+    return this._isDone;
+  }
+
+  declareDone() {
+    if (this._resolve === null) {
+      throw new Error("Promise has not had the time to initialize");
+    }
+    if (!this._isDone) {
+      this._isDone = true;
+      this._resolve();
+    }
+  }
+}


### PR DESCRIPTION
This relies on modifications to chainsauce (already accounted for in package-lock).