### PR TITLE
fix: pass env var to fly since .env is not included in Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Write commit hash to .env
-        run: |
-          echo BUILD_TAG=`git rev-parse --short HEAD` >.env
-
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Build
@@ -28,14 +24,14 @@ jobs:
 
       - name: Deploy to Staging
         run: |
-          flyctl -c fly.staging.toml deploy --remote-only --wait-timeout=3600
+          flyctl -c fly.staging.toml deploy --remote-only --wait-timeout=3600 --env BUILD_TAG=`git rev-parse --short HEAD` >.env
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Deploy to Production
         run: |
-          flyctl -c fly.production.toml deploy --remote-only  --wait-timeout=3600
+          flyctl -c fly.production.toml deploy --remote-only  --wait-timeout=3600 --env BUILD_TAG=`git rev-parse --short HEAD` >.env
         if: ${{ github.ref == 'refs/heads/release' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Addendum to #186

Sets BUILD_TAG env var using `flyctl` because `.env` does not get included in `Dockerfile`. (Eventually we'll want `.env` in `Dockerfile` and switch `dotenv` to `dotenv-flow`, but this doesn't seem the right time and place to make that change.)