### PR TITLE
enh: handle passport API errors and test passport provider

### DIFF
--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -199,8 +199,8 @@ export default class Calculator {
       }
     );
 
-    const contributionPromises = Promise.all(
-      votesWithCoefficients.map(async (vote) => {
+    const contributions: Contribution[] = votesWithCoefficients.flatMap(
+      (vote) => {
         const scaleFactor = Math.pow(10, 4);
         const coefficient = BigInt(
           Math.trunc(
@@ -218,12 +218,8 @@ export default class Calculator {
             amount: multipliedAmount,
           },
         ];
-      })
+      }
     );
-
-    const contributions: Array<Contribution> = (
-      await contributionPromises
-    ).flat();
 
     const results = linearQF(contributions, matchAmount, matchTokenDecimals, {
       minimumAmount: 0n,

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -38,9 +38,16 @@ export class FileSystemDataProvider implements DataProvider {
   async loadFile<T>(description: string, path: string): Promise<Array<T>> {
     const fullPath = `${this.basePath}/${path}`;
 
-    const data = await fs.readFile(fullPath, "utf8");
-
-    return JSON.parse(data) as Array<T>;
+    try {
+      const data = await fs.readFile(fullPath, "utf8");
+      return JSON.parse(data) as Array<T>;
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        throw new FileNotFoundError(description);
+      } else {
+        throw err;
+      }
+    }
   }
 }
 

--- a/src/http/api/v1/exports.ts
+++ b/src/http/api/v1/exports.ts
@@ -4,8 +4,6 @@ import {
 } from "csv-writer";
 import { JsonStorage } from "chainsauce";
 import express from "express";
-import fs from "fs";
-import path from "path";
 import { pino } from "pino";
 
 import database from "../../../database.js";
@@ -13,7 +11,6 @@ import { createPriceProvider } from "../../../prices/provider.js";
 import { Round, Application, Vote } from "../../../indexer/types.js";
 import { getVotesWithCoefficients } from "../../../calculator/votes.js";
 import ClientError from "../clientError.js";
-import { PassportScore } from "../../../passport/index.js";
 import { HttpApiConfig } from "../../app.js";
 
 export const createHandler = (config: HttpApiConfig): express.Router => {

--- a/src/http/api/v1/exports.ts
+++ b/src/http/api/v1/exports.ts
@@ -73,26 +73,16 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
   }
 
   async function exportVoteCoefficientsCSV(db: JsonStorage, round: Round) {
-    const storageDir = config.storageDir;
-
-    const [applications, votes, passportScoresString] = await Promise.all([
+    const [applications, votes] = await Promise.all([
       db.collection<Application>(`rounds/${round.id}/applications`).all(),
       db.collection<Vote>(`rounds/${round.id}/votes`).all(),
-      fs.promises.readFile(path.join(storageDir, "/passport_scores.json"), {
-        encoding: "utf8",
-        flag: "r",
-      }),
     ]);
 
-    const passportScores = JSON.parse(
-      passportScoresString
-    ) as Array<PassportScore>;
-
-    const votesWithCoefficients = getVotesWithCoefficients(
+    const votesWithCoefficients = await getVotesWithCoefficients(
       round,
       applications,
       votes,
-      passportScores,
+      config.passportProvider,
       {}
     );
 

--- a/src/http/api/v1/matches.ts
+++ b/src/http/api/v1/matches.ts
@@ -1,5 +1,4 @@
 import express, { Response, Request } from "express";
-
 const upload = multer();
 import multer from "multer";
 import ClientError from "../clientError.js";
@@ -81,6 +80,7 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
     const calculatorOptions: CalculatorOptions = {
       priceProvider: config.priceProvider,
       dataProvider: config.dataProvider,
+      passportProvider: config.passportProvider,
       chainId: chainId,
       roundId: roundId,
       minimumAmountUSD: minimumAmountUSD ? Number(minimumAmountUSD) : undefined,

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -9,6 +9,7 @@ import serveIndex from "serve-index";
 
 import { createHandler as createApiHandler } from "./api/v1/index.js";
 import { PriceProvider } from "../prices/provider.js";
+import { PassportProvider } from "../passport/index.js";
 import { DataProvider } from "../calculator/index.js";
 
 export interface HttpApiConfig {
@@ -18,6 +19,7 @@ export interface HttpApiConfig {
   buildTag: string | null;
   priceProvider: PriceProvider;
   dataProvider: DataProvider;
+  passportProvider: PassportProvider;
 }
 
 interface HttpApi {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,10 +106,6 @@ async function catchupAndWatchPassport(
 ): Promise<PassportProvider> {
   await fs.mkdir(config.storageDir, { recursive: true });
   const SCORES_FILE = path.join(config.storageDir, "passport_scores.json");
-  const VALID_ADDRESSES_FILE = path.join(
-    config.storageDir,
-    "passport_valid_addresses.json"
-  );
 
   const passportProvider = createPassportProvider({
     apiKey: config.passportApiKey,
@@ -124,16 +120,8 @@ async function catchupAndWatchPassport(
         return null;
       }
     },
-    persist: async ({ passports, validAddresses }) => {
-      await Promise.all([
-        fs.writeFile(SCORES_FILE, JSON.stringify(passports, null, 2), "utf8"),
-        fs.writeFile(
-          VALID_ADDRESSES_FILE,
-          JSON.stringify(validAddresses, null, 2),
-          "utf8"
-        ),
-      ]);
-    },
+    persist: (passports) =>
+      fs.writeFile(SCORES_FILE, JSON.stringify(passports, null, 2), "utf8"),
   });
 
   await passportProvider.start({ watch: !config.runOnce });

--- a/src/passport/index.test.fixtures.ts
+++ b/src/passport/index.test.fixtures.ts
@@ -1,0 +1,41 @@
+export const SAMPLE_PASSPORT_DATA = [
+  {
+    address: "voter-1",
+    score: "1.000000000",
+    status: "DONE",
+    last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
+    evidence: {
+      type: "ThresholdScoreCheck",
+      success: true,
+      rawScore: "27.21",
+      threshold: "15.00000",
+    },
+    error: null,
+  },
+  {
+    address: "voter-2",
+    score: "1.000000000",
+    status: "DONE",
+    last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
+    evidence: {
+      type: "ThresholdScoreCheck",
+      success: false,
+      rawScore: "10.03",
+      threshold: "15.00000",
+    },
+    error: null,
+  },
+  {
+    address: "voter-3",
+    score: "1.000000000",
+    status: "DONE",
+    last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
+    evidence: {
+      type: "ThresholdScoreCheck",
+      success: true,
+      rawScore: "30.03",
+      threshold: "15.00000",
+    },
+    error: null,
+  },
+];

--- a/src/passport/index.test.fixtures.ts
+++ b/src/passport/index.test.fixtures.ts
@@ -1,41 +1,43 @@
-export const SAMPLE_PASSPORT_DATA = [
-  {
-    address: "voter-1",
-    score: "1.000000000",
-    status: "DONE",
-    last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
-    evidence: {
-      type: "ThresholdScoreCheck",
-      success: true,
-      rawScore: "27.21",
-      threshold: "15.00000",
+export const SAMPLE_PASSPORT_DATA = {
+  items: [
+    {
+      address: "voter-1",
+      score: "1.000000000",
+      status: "DONE",
+      last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
+      evidence: {
+        type: "ThresholdScoreCheck",
+        success: true,
+        rawScore: "27.21",
+        threshold: "15.00000",
+      },
+      error: null,
     },
-    error: null,
-  },
-  {
-    address: "voter-2",
-    score: "1.000000000",
-    status: "DONE",
-    last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
-    evidence: {
-      type: "ThresholdScoreCheck",
-      success: false,
-      rawScore: "10.03",
-      threshold: "15.00000",
+    {
+      address: "voter-2",
+      score: "1.000000000",
+      status: "DONE",
+      last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
+      evidence: {
+        type: "ThresholdScoreCheck",
+        success: false,
+        rawScore: "10.03",
+        threshold: "15.00000",
+      },
+      error: null,
     },
-    error: null,
-  },
-  {
-    address: "voter-3",
-    score: "1.000000000",
-    status: "DONE",
-    last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
-    evidence: {
-      type: "ThresholdScoreCheck",
-      success: true,
-      rawScore: "30.03",
-      threshold: "15.00000",
+    {
+      address: "voter-3",
+      score: "1.000000000",
+      status: "DONE",
+      last_score_timestamp: "2023-05-08T10:17:52.872812+00:00",
+      evidence: {
+        type: "ThresholdScoreCheck",
+        success: true,
+        rawScore: "30.03",
+        threshold: "15.00000",
+      },
+      error: null,
     },
-    error: null,
-  },
-];
+  ],
+};

--- a/src/passport/index.test.ts
+++ b/src/passport/index.test.ts
@@ -30,9 +30,9 @@ describe("passport provider", () => {
     });
 
     test("throws if stopping is attempted before starting", () => {
-      expect(() =>
-        passportProvider.stop()
-      ).toThrowErrorMatchingInlineSnapshot('"Service not started"');
+      expect(() => passportProvider.stop()).toThrowErrorMatchingInlineSnapshot(
+        '"Service not started"'
+      );
     });
   });
 

--- a/src/passport/index.test.ts
+++ b/src/passport/index.test.ts
@@ -34,6 +34,8 @@ describe("passport provider", () => {
     scorerId: "123",
     load: async () => Promise.resolve(SAMPLE_PASSPORT_DATA.items),
     persist: async () => {},
+    delayBetweenFullUpdatesMs: 10,
+    delayBetweenPageRequestsMs: 10,
   });
 
   describe("lifecycle", () => {
@@ -71,7 +73,9 @@ describe("passport provider", () => {
         fetch: fetchMock,
       });
 
-      await passportProvider.start();
+      const starting = passportProvider.start();
+      await vi.advanceTimersToNextTimerAsync();
+      await starting;
 
       expect(fetchMock.mock.calls).toMatchInlineSnapshot(`
         [
@@ -121,7 +125,9 @@ describe("passport provider", () => {
         fetch: fetchMock,
       });
 
-      await expect(passportProvider.start()).resolves.not.toThrow();
+      const starting = passportProvider.start();
+      await vi.advanceTimersToNextTimerAsync();
+      await expect(starting).resolves.not.toThrow();
 
       expect(fetchMock.mock.calls).toMatchInlineSnapshot(`
         [
@@ -189,7 +195,9 @@ describe("passport provider", () => {
         fetch: fetchMock,
       });
 
-      await passportProvider.start();
+      const starting = passportProvider.start();
+      await vi.advanceTimersToNextTimerAsync();
+      await starting;
 
       expect(fetchMock.mock.calls).toMatchInlineSnapshot(`
         [
@@ -290,7 +298,9 @@ describe("passport provider", () => {
         fetch: fetchMock,
       });
 
-      await expect(passportProvider.start()).resolves.not.toThrow();
+      const starting = passportProvider.start();
+      await vi.advanceTimersToNextTimerAsync();
+      await expect(starting).resolves.not.toThrow();
 
       expect(fetchMock.mock.calls).toMatchInlineSnapshot(`
         [
@@ -332,7 +342,7 @@ describe("passport provider", () => {
       `);
     });
 
-    test.only("when remote dataset contains more than 1000 items, they are downloaded in batches", async () => {
+    test("when remote dataset contains more than 1000 items, they are downloaded in batches", async () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce({
@@ -354,7 +364,10 @@ describe("passport provider", () => {
         fetch: fetchMock,
       });
 
-      await passportProvider.start();
+      const starting = passportProvider.start();
+      await vi.advanceTimersToNextTimerAsync();
+      await vi.advanceTimersToNextTimerAsync();
+      await starting;
 
       expect(fetchMock.mock.calls).toMatchInlineSnapshot(`
         [
@@ -404,7 +417,9 @@ describe("passport provider", () => {
   describe("querying", () => {
     beforeEach(async () => {
       passportProvider = createPassportProvider(getTestConfig());
-      await passportProvider.start();
+      const starting = passportProvider.start();
+      await vi.advanceTimersToNextTimerAsync();
+      await starting;
     });
 
     afterEach(() => {

--- a/src/passport/index.test.ts
+++ b/src/passport/index.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Logger } from "pino";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { createPassportProvider, PassportProvider } from "./index.js";
+import { SAMPLE_PASSPORT_DATA } from "./index.test.fixtures.js";
+
+const DUMMY_LOGGER = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+describe("passport provider", () => {
+  let passportProvider: PassportProvider;
+
+  describe("lifecycle", () => {
+    passportProvider = createPassportProvider({
+      apiKey: "dummy-key",
+      logger: DUMMY_LOGGER,
+      scorerId: "123",
+      load: async () => Promise.resolve(SAMPLE_PASSPORT_DATA),
+      persist: async () => {},
+    });
+
+    test("throws if reading is attempted before starting", async () => {
+      await expect(() =>
+        passportProvider.getScoreByAddress("voter-1")
+      ).rejects.toMatchInlineSnapshot("[Error: Service not started]");
+    });
+
+    test("throws if stopping is attempted before starting", () => {
+      expect(() =>
+        passportProvider.stop()
+      ).toThrowErrorMatchingInlineSnapshot('"Service not started"');
+    });
+  });
+
+  describe("queries", () => {
+    beforeEach(async () => {
+      await passportProvider.start();
+    });
+
+    afterEach(() => {
+      passportProvider.stop();
+    });
+
+    test("provides score for address, if available", async () => {
+      await passportProvider.start();
+
+      const score = await passportProvider.getScoreByAddress("voter-1");
+
+      expect(score).toMatchInlineSnapshot(`
+      {
+        "address": "voter-1",
+        "error": null,
+        "evidence": {
+          "rawScore": "27.21",
+          "success": true,
+          "threshold": "15.00000",
+          "type": "ThresholdScoreCheck",
+        },
+        "last_score_timestamp": "2023-05-08T10:17:52.872812+00:00",
+        "score": "1.000000000",
+        "status": "DONE",
+      }
+    `);
+    });
+
+    test("returns undefined when score is not available", async () => {
+      await passportProvider.start();
+
+      const score = await passportProvider.getScoreByAddress(
+        "non-existing-address"
+      );
+
+      expect(score).toEqual(undefined);
+    });
+  });
+});

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import sleep from "sleep-promise";
-import { ethers } from "ethers";
 import fetch from "make-fetch-happen";
 import { Logger } from "pino";
 
@@ -27,10 +26,7 @@ interface PassportProviderConfig {
   apiKey: string;
   scorerId: string;
   logger: Logger;
-  persist: (data: {
-    passports: PassportScore[];
-    validAddresses: string[];
-  }) => Promise<void>;
+  persist: (passports: PassportScore[]) => Promise<void>;
   load: () => Promise<PassportScore[] | null>;
 }
 
@@ -196,16 +192,8 @@ export const createPassportProvider = (
       await sleep(DELAY_BETWEEN_PAGE_REQUESTS_MS);
     }
 
-    const validAddresses = passports
-      .filter((passport) => passport.evidence && passport.evidence.success)
-      .map((passport) => {
-        return ethers.utils.getAddress(passport.address);
-      });
-
-    logger.debug(
-      `persisting ${passports.length} passports (${validAddresses.length} valid addresses)`
-    );
-    await config.persist({ passports, validAddresses });
+    logger.debug(`persisting ${passports.length} passports`);
+    await config.persist(passports);
 
     return passports;
   };

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import sleep from "sleep-promise";
-import fetch from "make-fetch-happen";
+import enhancedFetch from "make-fetch-happen";
 import { Logger } from "pino";
 
 const PASSPORT_API_MAX_ITEMS_LIMIT = 1000;
@@ -62,7 +62,7 @@ export const createPassportProvider = (
 
   const baseRequestUri = `https://api.scorer.gitcoin.co/registry/score/${config.scorerId}`;
   const { logger } = config;
-  const fetch = config.fetch ?? global.fetch;
+  const fetch = config.fetch ?? enhancedFetch;
 
   // STATE
 

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -23,7 +23,7 @@ export type PassportScore = {
   detail?: string;
 };
 
-interface PassportConfig {
+interface PassportProviderConfig {
   apiKey: string;
   scorerId: string;
   logger: Logger;
@@ -34,13 +34,32 @@ interface PassportConfig {
   load: () => Promise<PassportScore[] | null>;
 }
 
-interface PassportUpdater {
+type PassportProviderState =
+  | {
+      type: "stopped";
+      scoresByAddressMap: null;
+      pollTimeoutId: null;
+    }
+  | {
+      type: "starting";
+      scoresByAddressMap: null;
+      pollTimeoutId: null;
+    }
+  | {
+      type: "ready";
+      scoresByAddressMap: { [address: string]: PassportScore };
+      pollTimeoutId: NodeJS.Timeout | null;
+    };
+
+export interface PassportProvider {
   start: (opts?: { watch: boolean }) => Promise<void>;
+  stop: () => void;
+  getScoreByAddress: (address: string) => Promise<PassportScore | undefined>;
 }
 
-export const createPassportUpdater = (
-  config: PassportConfig
-): PassportUpdater => {
+export const createPassportProvider = (
+  config: PassportProviderConfig
+): PassportProvider => {
   // CONFIG
 
   const baseRequestUri = `https://api.scorer.gitcoin.co/registry/score/${config.scorerId}`;
@@ -48,83 +67,133 @@ export const createPassportUpdater = (
 
   // STATE
 
-  let passports: PassportScore[] = [];
+  let state: PassportProviderState = {
+    type: "stopped",
+    scoresByAddressMap: null,
+    pollTimeoutId: null,
+  };
 
   // API
 
   const start = async (opts = { watch: true }) => {
-    logger.info("starting");
+    logger.info(`${state.type} => starting`);
+    state = { type: "starting", scoresByAddressMap: null, pollTimeoutId: null };
 
     logger.debug("loading locally persisted passports...");
-    passports = (await config.load()) ?? [];
 
-    if (passports.length === 0) {
-      logger.debug("no passports found locally, will do initial update");
-      // If nothing was read from storage, don't return until
-      await updateEntireDataset();
-    } else {
-      logger.debug(`loaded ${passports.length} passports`);
+    let initialPassportDataset: PassportScore[] | null = await config.load();
+    if (initialPassportDataset === null) {
+      logger.debug(
+        "no passports dataset found locally, fetch remote before starting"
+      );
+      initialPassportDataset = await fetchEntireDataset();
     }
 
+    logger.debug(`loaded ${initialPassportDataset.length} passports`);
+
+    const scoresByAddressMap = computeScoresByAddressMap(
+      initialPassportDataset
+    );
+
+    logger.info(`${state.type} => ready`);
+    state = { ...state, type: "ready", scoresByAddressMap };
     if (opts.watch) {
-      setTimeout(poll, DELAY_BETWEEN_FULL_UPDATES_MS);
+      state.pollTimeoutId = setTimeout(poll, DELAY_BETWEEN_FULL_UPDATES_MS);
     }
+  };
+
+  const stop = () => {
+    if (state.type !== "ready") {
+      throw new Error("Service not started");
+    }
+
+    if (state.pollTimeoutId !== null) {
+      clearTimeout(state.pollTimeoutId);
+    }
+
+    logger.info(`${state.type} => stopped`);
+    state = { type: "stopped", scoresByAddressMap: null, pollTimeoutId: null };
+  };
+
+  const getScoreByAddress = async (
+    address: string
+  ): Promise<PassportScore | undefined> => {
+    if (state.type !== "ready") {
+      throw new Error("Service not started");
+    }
+
+    // Async not really necessary right now because data is in memory, but this
+    // could easily be imply I/O in the future, so might as well make it async
+    // already
+    return Promise.resolve(state.scoresByAddressMap[address]);
   };
 
   // INTERNALS
 
+  const computeScoresByAddressMap = (
+    passportScores: PassportScore[]
+  ): Record<string, PassportScore> => {
+    const scoresByAddressMap: Record<string, PassportScore> = {};
+    for (const score of passportScores) {
+      scoresByAddressMap[score.address.toLocaleLowerCase()] = score;
+    }
+    return scoresByAddressMap;
+  };
+
   const poll = async (): Promise<void> => {
-    // Can be switched to incremental updates once https://github.com/gitcoinco/passport/issues/1414 is fixed
-    await updateEntireDataset();
+    if (state.type !== "ready") {
+      throw new Error("Service not started");
+    }
+
+    const passports = await fetchEntireDataset();
+
+    for (const score of passports) {
+      state.scoresByAddressMap[score.address.toLocaleLowerCase()] = score;
+    }
+
     setTimeout(poll, DELAY_BETWEEN_FULL_UPDATES_MS);
   };
 
-  const updateEntireDataset = async (): Promise<void> => {
-    passports.length = 0;
-    await updateIncrementally();
+  const _TODO_fetchUpdates = async (): Promise<PassportScore[]> => {
+    // https://github.com/gitcoinco/allo-indexer/issues/191
+    return Promise.resolve([]);
   };
 
-  const updateIncrementally = async (): Promise<void> => {
+  const fetchEntireDataset = async (): Promise<PassportScore[]> => {
     logger.debug("updating passports...");
     const remotePassportCount = await fetchRemotePassportCount();
+    const passports: PassportScore[] = [];
 
-    const newPassportCount = remotePassportCount - passports.length;
-    if (newPassportCount > 0) {
-      logger.debug(
-        `found ${newPassportCount} new passports remotely; fetching...`
-      );
+    let offset = 0;
+    while (offset < remotePassportCount) {
+      const requestUri = `${baseRequestUri}?offset=${offset}&limit=${PASSPORT_API_MAX_ITEMS_LIMIT}`;
 
-      let offset = passports.length;
-      while (offset < newPassportCount) {
-        const requestUri = `${baseRequestUri}?offset=${offset}&limit=${PASSPORT_API_MAX_ITEMS_LIMIT}`;
-
-        if (offset % 20000 === 0) {
-          // Only log every 10000 scores to reduce log noise
-          logger.debug({
-            msg: `fetching from ${offset} up to ${remotePassportCount} in batches of ${PASSPORT_API_MAX_ITEMS_LIMIT}`,
-            requestUri,
-          });
-        }
-
-        // @ts-ignore
-        const res = await fetch(requestUri, {
-          headers: { authorization: `Bearer ${config.apiKey}` },
-          retry: {
-            retries: 5,
-            randomize: true,
-            maxTimeout: 5000,
-          },
+      if (offset % 20000 === 0) {
+        // Only log every 10000 scores to reduce log noise
+        logger.debug({
+          msg: `fetching from ${offset} up to ${remotePassportCount} in batches of ${PASSPORT_API_MAX_ITEMS_LIMIT}`,
+          requestUri,
         });
-
-        const { items: passportBatch } = (await res.json()) as {
-          items: PassportScore[];
-        };
-
-        passports.push(...passportBatch);
-
-        offset += PASSPORT_API_MAX_ITEMS_LIMIT;
-        await sleep(DELAY_BETWEEN_PAGE_REQUESTS_MS);
       }
+
+      // @ts-ignore
+      const res = await fetch(requestUri, {
+        headers: { authorization: `Bearer ${config.apiKey}` },
+        retry: {
+          retries: 5,
+          randomize: true,
+          maxTimeout: 5000,
+        },
+      });
+
+      const { items: passportBatch } = (await res.json()) as {
+        items: PassportScore[];
+      };
+
+      passports.push(...passportBatch);
+
+      offset += PASSPORT_API_MAX_ITEMS_LIMIT;
+      await sleep(DELAY_BETWEEN_PAGE_REQUESTS_MS);
     }
 
     const validAddresses = passports
@@ -137,6 +206,8 @@ export const createPassportUpdater = (
       `persisting ${passports.length} passports (${validAddresses.length} valid addresses)`
     );
     await config.persist({ passports, validAddresses });
+
+    return passports;
   };
 
   const fetchRemotePassportCount = async (): Promise<number> => {
@@ -152,5 +223,5 @@ export const createPassportUpdater = (
 
   // EXPORTS
 
-  return { start };
+  return { start, stop, getScoreByAddress };
 };

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -196,6 +196,7 @@ export const createPassportProvider = (
         });
       }
 
+      // @ts-ignore types from make-fetch-happen are conflicting with types from global fetch in CI
       const res = await fetch(requestUri, {
         headers: { authorization: `Bearer ${config.apiKey}` },
         retry: {

--- a/src/test/http/app.test.ts
+++ b/src/test/http/app.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../calculator/index.js";
 import { PriceProvider } from "../../prices/provider.js";
 import { Logger } from "pino";
+import { PassportScore } from "../../passport/index.js";
 
 vi.spyOn(os, "hostname").mockReturnValue("dummy-hostname");
 
@@ -39,6 +40,23 @@ export class TestPriceProvider {
   }
 }
 
+class TestPassportProvider {
+  _fixture: PassportScore[] | null = null;
+
+  async start() {}
+
+  async stop() {}
+
+  async getScoreByAddress(address: string): Promise<PassportScore | undefined> {
+    if (this._fixture === null) {
+      this._fixture = JSON.parse(
+        await loadFixture("passport_scores")
+      ) as PassportScore[];
+    }
+    return this._fixture.find((score) => score.address === address);
+  }
+}
+
 export class TestDataProvider implements DataProvider {
   fixtures: Fixtures;
 
@@ -48,6 +66,9 @@ export class TestDataProvider implements DataProvider {
 
   async loadFile<T>(description: string, path: string): Promise<Array<T>> {
     const fixture = this.fixtures[path];
+    // XXX this is not present in the actual loadFile in the
+    // FileSystemDataProvider, so the tests that check for 404 are verifying
+    // behavior that is not implemented
     if (fixture === undefined) {
       throw new FileNotFoundError(description);
     }
@@ -77,6 +98,7 @@ describe("server", () => {
         storageDir: "/dev/null",
         buildTag: "123abc",
         priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+        passportProvider: new TestPassportProvider(),
         dataProvider: new TestDataProvider({
           "1/rounds/0x1234/votes.json": "votes",
           "1/rounds/0x1234/applications.json": "applications",
@@ -119,11 +141,12 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -140,11 +163,12 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -161,11 +185,12 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -182,11 +207,12 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -203,11 +229,12 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -227,11 +254,12 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": "rounds",
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -293,6 +321,7 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
@@ -307,7 +336,7 @@ describe("server", () => {
                 metadata: {},
               },
             ],
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -370,11 +399,12 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes-with-bad-recipient",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": "rounds",
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -436,11 +466,11 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": "rounds",
-            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -562,13 +592,14 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds/0x2/votes.json": "votes",
             "1/rounds/0x2/applications.json": "applications",
             "1/rounds.json": "rounds",
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -773,13 +804,14 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds/0x3/votes.json": "votes",
             "1/rounds/0x3/applications.json": "applications",
             "1/rounds.json": "rounds",
-            "passport_scores.json": "passport_scores",
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -935,13 +967,15 @@ describe("server", () => {
           port: 0,
           storageDir: "/dev/null",
           priceProvider: new TestPriceProvider() as unknown as PriceProvider,
+          passportProvider: new TestPassportProvider(),
           dataProvider: new TestDataProvider({
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds/0x4/votes.json": "votes",
             "1/rounds/0x4/applications.json": "applications",
             "1/rounds.json": "rounds",
-            "passport_scores.json": "passport_scores",
+
+            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;

--- a/src/test/http/app.test.ts
+++ b/src/test/http/app.test.ts
@@ -66,9 +66,6 @@ export class TestDataProvider implements DataProvider {
 
   async loadFile<T>(description: string, path: string): Promise<Array<T>> {
     const fixture = this.fixtures[path];
-    // XXX this is not present in the actual loadFile in the
-    // FileSystemDataProvider, so the tests that check for 404 are verifying
-    // behavior that is not implemented
     if (fixture === undefined) {
       throw new FileNotFoundError(description);
     }

--- a/src/test/http/app.test.ts
+++ b/src/test/http/app.test.ts
@@ -143,7 +143,6 @@ describe("server", () => {
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -165,7 +164,6 @@ describe("server", () => {
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -187,7 +185,6 @@ describe("server", () => {
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -209,7 +206,6 @@ describe("server", () => {
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -231,7 +227,6 @@ describe("server", () => {
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": [], // empty file so the round won't be found
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         });
@@ -256,7 +251,6 @@ describe("server", () => {
             "1/rounds/0x1234/votes.json": "votes",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": "rounds",
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -333,7 +327,6 @@ describe("server", () => {
                 metadata: {},
               },
             ],
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -401,7 +394,6 @@ describe("server", () => {
             "1/rounds/0x1234/votes.json": "votes-with-bad-recipient",
             "1/rounds/0x1234/applications.json": "applications",
             "1/rounds.json": "rounds",
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -596,7 +588,6 @@ describe("server", () => {
             "1/rounds/0x2/votes.json": "votes",
             "1/rounds/0x2/applications.json": "applications",
             "1/rounds.json": "rounds",
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -808,7 +799,6 @@ describe("server", () => {
             "1/rounds/0x3/votes.json": "votes",
             "1/rounds/0x3/applications.json": "applications",
             "1/rounds.json": "rounds",
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;
@@ -971,8 +961,6 @@ describe("server", () => {
             "1/rounds/0x4/votes.json": "votes",
             "1/rounds/0x4/applications.json": "applications",
             "1/rounds.json": "rounds",
-
-            //            "passport_scores.json": "passport_scores",
           }) as DataProvider,
           buildTag: "123abc",
         }).app;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "allowJs": true,
     "esModuleInterop": true,
     "moduleResolution": "nodenext",
-    "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    watchExclude: [...configDefaults.watchExclude, "data", "test"],
+  },
+});


### PR DESCRIPTION
closes #203 

- recover from HTTP 4xx and 5xx from Passport API
- recover from content errors (e.g. invalid JSON) Passport API
- refactor PassportProvider so as to allow unit testing
- add unit tests (coverage should be complete or close to it)
- encapsulate passport data in PassportProvider — Calculator asks PassportProvider instead of reading disk dumps
- prepare for #191 
- remove `valid_addresses` file and related code since it's not used anywhere

Review notes:
- `src/passport/index.ts` has changed enough that a diff review wouldn't make sense, I suggest reading the source itself rather than the diff
- @vacekj review optional 