### PR TITLE
enh: run prettier and lint in git hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Write commit hash to .env
-        run: |
-          echo BUILD_TAG=`git rev-parse --short HEAD` >.env
-
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Build

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+  "trailingComma": "es5"
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+pre-commit:
+  parallel: true
+  commands:
+    prettier:
+      glob: "*.{js,ts,jsx,tsx}"
+      run: npx prettier --write {staged_files}
+
+pre-push:
+  parallel: true
+  commands:
+    eslint:
+      glob: "*.{js,ts,jsx,tsx}"
+      run: npm run lint {staged_files}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "@typescript-eslint/parser": "^5.55.0",
         "concurrently": "^8.2.0",
         "eslint": "^8.36.0",
-        "prettier": "^2.8.4",
+        "lefthook": "^1.4.8",
+        "prettier": "^3.0.1",
         "supertest": "^6.3.3",
         "tsx": "^3.12.7",
         "typescript": "^4.9.5",
@@ -4385,6 +4386,130 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
+    "node_modules/lefthook": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.4.8.tgz",
+      "integrity": "sha512-SALO6nIy0aizM3FJdy4cNdUy9qKJyGZo6f8gZdzhBuKLMrwnm9YeMdJmQKeEPZA9E2mDSqdHGJjvMlKrm+04Pg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.4.8",
+        "lefthook-darwin-x64": "1.4.8",
+        "lefthook-freebsd-arm64": "1.4.8",
+        "lefthook-freebsd-x64": "1.4.8",
+        "lefthook-linux-arm64": "1.4.8",
+        "lefthook-linux-x64": "1.4.8",
+        "lefthook-windows-arm64": "1.4.8",
+        "lefthook-windows-x64": "1.4.8"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.4.8.tgz",
+      "integrity": "sha512-wUaasRq7P1BNAlGwu/vONVHrwlrTwQGEhyn0leciEcnQCUN8aTeEC4hkxHmxisgQVQTdidYkCSWcsaEFn84xzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.4.8.tgz",
+      "integrity": "sha512-uUkQeU08szL4IpKVQSlhzNObZ79YkwmZ3fZDmF+jjP69LMESEVY7Y+cuQI0RG4YOTXHGBqZs3MPUZ7ZygBrhcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.4.8.tgz",
+      "integrity": "sha512-X4rWxsmxfyMRgfIOqAnk2zrMzlJV0fANEDYNuUYBVbgH8IYAy1cyVQlolgeC8NhFW8VaJ3AztbWpnR1M8zEByA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.4.8.tgz",
+      "integrity": "sha512-ijenlZtEZpbnLFWTZdsIDmVdLzkaTkeEQVjjHEXdo2GBjLmdLYk8hRQiY/7oUxFe/JO1RLuhfIlPkKLtYz1iTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.4.8.tgz",
+      "integrity": "sha512-lOsJymblZ8nIpgm2lLfWx33tXtkdamK0lZThbSK4uwZQWFzSjr9qx21qZlJZ/mG8jZ5EY5Twhjqrt131CUXtMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.4.8.tgz",
+      "integrity": "sha512-tF/iQFZu9iR++C3UXvpeTQS50CtTdZWmeMJ49uAovu9qe3qpPdKoguorZSFDC2+OGYbd7wbulldpWhvgxarniA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.4.8.tgz",
+      "integrity": "sha512-ykqX5rm5UI6244cF6anf92p+JXNvuA/Ah3bpQKYSA5JoMG2vJmPZ9nIThq5ky/F90jXySBxcdZRdrridtagAbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.4.8.tgz",
+      "integrity": "sha512-wv8in0vku5eDpjNtri4s02kXbowEa6t/h8pHHUnCedmJJ2ImwwqGQJ1kwDVQL0U3bgdNWCfC2mUxVmtXoLQkBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "license": "MIT",
@@ -5321,15 +5446,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -9726,6 +9851,78 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
+    "lefthook": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.4.8.tgz",
+      "integrity": "sha512-SALO6nIy0aizM3FJdy4cNdUy9qKJyGZo6f8gZdzhBuKLMrwnm9YeMdJmQKeEPZA9E2mDSqdHGJjvMlKrm+04Pg==",
+      "dev": true,
+      "requires": {
+        "lefthook-darwin-arm64": "1.4.8",
+        "lefthook-darwin-x64": "1.4.8",
+        "lefthook-freebsd-arm64": "1.4.8",
+        "lefthook-freebsd-x64": "1.4.8",
+        "lefthook-linux-arm64": "1.4.8",
+        "lefthook-linux-x64": "1.4.8",
+        "lefthook-windows-arm64": "1.4.8",
+        "lefthook-windows-x64": "1.4.8"
+      }
+    },
+    "lefthook-darwin-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.4.8.tgz",
+      "integrity": "sha512-wUaasRq7P1BNAlGwu/vONVHrwlrTwQGEhyn0leciEcnQCUN8aTeEC4hkxHmxisgQVQTdidYkCSWcsaEFn84xzw==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-darwin-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.4.8.tgz",
+      "integrity": "sha512-uUkQeU08szL4IpKVQSlhzNObZ79YkwmZ3fZDmF+jjP69LMESEVY7Y+cuQI0RG4YOTXHGBqZs3MPUZ7ZygBrhcQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-freebsd-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.4.8.tgz",
+      "integrity": "sha512-X4rWxsmxfyMRgfIOqAnk2zrMzlJV0fANEDYNuUYBVbgH8IYAy1cyVQlolgeC8NhFW8VaJ3AztbWpnR1M8zEByA==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-freebsd-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.4.8.tgz",
+      "integrity": "sha512-ijenlZtEZpbnLFWTZdsIDmVdLzkaTkeEQVjjHEXdo2GBjLmdLYk8hRQiY/7oUxFe/JO1RLuhfIlPkKLtYz1iTQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-linux-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.4.8.tgz",
+      "integrity": "sha512-lOsJymblZ8nIpgm2lLfWx33tXtkdamK0lZThbSK4uwZQWFzSjr9qx21qZlJZ/mG8jZ5EY5Twhjqrt131CUXtMw==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-linux-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.4.8.tgz",
+      "integrity": "sha512-tF/iQFZu9iR++C3UXvpeTQS50CtTdZWmeMJ49uAovu9qe3qpPdKoguorZSFDC2+OGYbd7wbulldpWhvgxarniA==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-windows-arm64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.4.8.tgz",
+      "integrity": "sha512-ykqX5rm5UI6244cF6anf92p+JXNvuA/Ah3bpQKYSA5JoMG2vJmPZ9nIThq5ky/F90jXySBxcdZRdrridtagAbw==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-windows-x64": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.4.8.tgz",
+      "integrity": "sha512-wv8in0vku5eDpjNtri4s02kXbowEa6t/h8pHHUnCedmJJ2ImwwqGQJ1kwDVQL0U3bgdNWCfC2mUxVmtXoLQkBg==",
+      "dev": true,
+      "optional": true
+    },
     "levn": {
       "version": "0.4.1",
       "requires": {
@@ -10355,9 +10552,9 @@
       "version": "1.2.1"
     },
     "prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dev": "tsx watch src/index.ts --chains=mainnet,optimism,goerli,fantom,pgn-testnet,pgn-mainnet | pino-pretty",
     "build": "tsc",
     "lint": "eslint src",
-    "format": "prettier --write src",
     "test": "vitest run --reporter verbose",
     "test:watch": "vitest watch --reporter verbose",
     "deploy:development": "docker buildx build . -t registry.fly.io/indexer-development:latest && docker push registry.fly.io/indexer-development:latest && flyctl -c fly.development.toml --app indexer-development deploy -i registry.fly.io/indexer-development:latest"
@@ -57,7 +56,8 @@
     "@typescript-eslint/parser": "^5.55.0",
     "concurrently": "^8.2.0",
     "eslint": "^8.36.0",
-    "prettier": "^2.8.4",
+    "lefthook": "^1.4.8",
+    "prettier": "^3.0.1",
     "supertest": "^6.3.3",
     "tsx": "^3.12.7",
     "typescript": "^4.9.5",


### PR DESCRIPTION
closes #209 

Will decrease diff noise by ensuring that all contributions are formatted to the same style, and history noise by preventing commits with lint issues to be pushed.

The `trailingComma` setting in `.prettierrc.json` is due to the default having changed in 3.0. We can switch to the new default in a separate PR over the entire codebase, again to prevent noise.