### PR TITLE
fix: don't attempt to fetch prices from before a chain existed

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export type Chain = {
   rpc: string;
   name: string;
   id: ChainId;
+  pricesFromTimestamp: number;
   tokens: Token[];
   subscriptions: Subscription[];
 };
@@ -33,6 +34,7 @@ export const CHAINS: Chain[] = [
     id: 1,
     name: "mainnet",
     rpc: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY ?? ""}`,
+    pricesFromTimestamp: Date.UTC(2022, 11, 1, 0, 0, 0),
     tokens: [
       {
         code: "USDC",
@@ -83,6 +85,7 @@ export const CHAINS: Chain[] = [
     id: 5,
     name: "goerli",
     rpc: `https://goerli.infura.io/v3/${process.env.INFURA_API_KEY ?? ""}`,
+    pricesFromTimestamp: Date.UTC(2022, 11, 1, 0, 0, 0),
     tokens: [
       {
         code: "USDC",
@@ -188,6 +191,7 @@ export const CHAINS: Chain[] = [
     rpc: `https://opt-mainnet.g.alchemy.com/v2/${
       process.env.ALCHEMY_API_KEY ?? ""
     }`,
+    pricesFromTimestamp: Date.UTC(2022, 11, 1, 0, 0, 0),
     tokens: [
       {
         code: "USDC",
@@ -238,6 +242,7 @@ export const CHAINS: Chain[] = [
     id: 250,
     name: "fantom",
     rpc: "https://rpcapi.fantom.network",
+    pricesFromTimestamp: Date.UTC(2022, 11, 1, 0, 0, 0),
     tokens: [
       {
         code: "USDC",
@@ -291,6 +296,7 @@ export const CHAINS: Chain[] = [
     id: 58008,
     name: "pgn-testnet",
     rpc: "https://sepolia.publicgoods.network",
+    pricesFromTimestamp: Date.UTC(2023, 6, 12, 0, 0, 0),
     tokens: [
       {
         code: "ETH",
@@ -341,6 +347,7 @@ export const CHAINS: Chain[] = [
     id: 424,
     name: "pgn-mainnet",
     rpc: "https://rpc.publicgoods.network",
+    pricesFromTimestamp: Date.UTC(2023, 6, 12, 0, 0, 0),
     tokens: [
       {
         code: "ETH",

--- a/src/prices/updater.ts
+++ b/src/prices/updater.ts
@@ -17,9 +17,6 @@ import {
 } from "./common.js";
 
 const POLL_INTERVAL_MS = 60 * 1000;
-const EARLIEST_PRICE_TIMESTAMP = new Date(
-  Date.UTC(2022, 11, 1, 0, 0, 0)
-).getTime();
 
 export interface PriceUpdaterService {
   start: (opts?: { watch: boolean; toBlock: ToBlock }) => Promise<void>;
@@ -77,7 +74,7 @@ export function createPriceUpdater(
     // get last updated price
     const lastPriceAt = currentPrices.reduce(
       (acc, price) => Math.max(price.timestamp + hours(1), acc),
-      EARLIEST_PRICE_TIMESTAMP
+      config.chain.pricesFromTimestamp
     );
 
     let toDate = undefined;

--- a/src/utils/getBlockFromTimestamp.ts
+++ b/src/utils/getBlockFromTimestamp.ts
@@ -15,7 +15,12 @@ async function estimateBlockNumber(
 
   // Now, you can use `blocksPerSecond` to adjust your block number estimation.
   // For instance, if you know the target timestamp is X seconds away from startTimestamp, you could estimate:
-  const secondsToTarget = Math.abs(targetTimestamp - startTimestamp);
+  const secondsToTarget = targetTimestamp - startTimestamp;
+  if (secondsToTarget < 0) {
+    throw new Error(
+      "Estimated block is negative, this probably means that the timestamp precedes the deployment of the chain. Check chain config and ensure that `pricesFromTimestamp` is correct."
+    );
+  }
   const estimatedBlocksToTarget = blocksPerSecond * secondsToTarget;
   const estimatedBlockNumber = startBlock + Math.round(estimatedBlocksToTarget);
 


### PR DESCRIPTION
fixes #227 

- set date to begin fetching prices from per-chain
- add sanity check that throws in case the date is set incorrectly
