### PR TITLE
feat: add support for gitcoinvote token

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -271,6 +271,15 @@ export const CHAINS: Chain[] = [
           address: "0x0000000000000000000000000000000000000000",
         },
       },
+      {
+        code: "GcV",
+        address: "0x83791638da5EB2fAa432aff1c65fbA47c5D29510",
+        decimals: 18,
+        priceSource: {
+          chainId: 250,
+          address: "0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E",
+        },
+      },
     ],
     subscriptions: [
       {


### PR DESCRIPTION
closes #234 

Note: I took DAI on Fantom as price source instead of DAI on mainnet.