### PR TITLE
enh: update chainsauce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2623,7 +2623,7 @@
     },
     "node_modules/chainsauce": {
       "version": "1.0.19",
-      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#e5546e173fe09a8bec84c1bd7da22b2cc2b439cb",
+      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#a08402549b0342b7d7e3c919b57d81388a2c8cf3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.2.0",
@@ -8607,7 +8607,7 @@
       }
     },
     "chainsauce": {
-      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#e5546e173fe09a8bec84c1bd7da22b2cc2b439cb",
+      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#a08402549b0342b7d7e3c919b57d81388a2c8cf3",
       "from": "chainsauce@github:gitcoinco/chainsauce",
       "requires": {
         "better-sqlite3": "^8.2.0",


### PR DESCRIPTION
This brings in updates to chainsauce that will later be required to enable event replay.