### PR TITLE
chore: decrease logs at warn level

### DIFF
--- a/src/prices/provider.ts
+++ b/src/prices/provider.ts
@@ -29,7 +29,7 @@ export interface PriceProvider {
 export function createPriceProvider(
   config: PriceProviderConfig
 ): PriceProvider {
-  const { logger } = config;
+  const { logger: _logger } = config;
 
   // STATE
 
@@ -153,14 +153,16 @@ export function createPriceProvider(
     if (blockNumber === undefined) {
       closestPrice = lastAvailablePrice;
     } else if (blockNumber > lastAvailablePrice.block) {
-      logger.warn(
-        `requested price for block ${blockNumber} newer than last available ${lastAvailablePrice.block}`
-      );
+      // TODO decide how to warn about potential inconsistencies without spamming
+      // logger.warn(
+      //   `requested price for block ${blockNumber} newer than last available ${lastAvailablePrice.block}`
+      // );
       closestPrice = lastAvailablePrice;
     } else if (blockNumber < firstAvailablePrice.block) {
-      logger.warn(
-        `requested price for block ${blockNumber} older than earliest available ${firstAvailablePrice.block}`
-      );
+      // TODO decide how to warn about potential inconsistencies without spamming
+      // logger.warn(
+      //   `requested price for block ${blockNumber} older than earliest available ${firstAvailablePrice.block}`
+      // );
       closestPrice = firstAvailablePrice;
     } else {
       closestPrice =


### PR DESCRIPTION
The `warn` logs in the price updater are triggered too often and make it difficult to notice more important messages.