### PR TITLE
enh: specify chains via env var to ease deployment and local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+INDEXED_CHAINS=mainnet,optimism,goerli,fantom,pgn-testnet,pgn-mainnet,goerli
 INFURA_API_KEY=
 ALCHEMY_API_KEY=
 PASSPORT_API_KEY=

--- a/fly.development.toml
+++ b/fly.development.toml
@@ -12,7 +12,8 @@ kill_timeout = 5
   LOG_LEVEL = "debug"
   STORAGE_DIR = "/mnt/indexer/data"
   CACHE_DIR = "/mnt/indexer/cache"
-  # BUILD_TAG = # set in deploy action
+  INDEXED_CHAINS = "mainnet,optimism,fantom,pgn-testnet,pgn-mainnet"
+  # BUILD_TAG = # set in deploy github action
 
 [processes]
   web = "npm start"

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -12,7 +12,8 @@ kill_timeout = 5
   LOG_LEVEL = "debug"
   STORAGE_DIR = "/mnt/indexer/data"
   CACHE_DIR = "/mnt/indexer/cache"
-  # BUILD_TAG = # set in deploy action
+  INDEXED_CHAINS = "mainnet,optimism,fantom,pgn-testnet,pgn-mainnet"
+  # BUILD_TAG = # set in deploy github action
 
 [processes]
   web = "npm start"

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -12,7 +12,8 @@ kill_timeout = 5
   LOG_LEVEL = "debug"
   STORAGE_DIR = "/mnt/indexer/data"
   CACHE_DIR = "/mnt/indexer/cache"
-  # BUILD_TAG = # set in deploy action
+  INDEXED_CHAINS = "mainnet,optimism,fantom,pgn-testnet,pgn-mainnet"
+  # BUILD_TAG = # set in deploy github action
 
 [processes]
   web = "npm start"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "dist/src/indexer/index.js",
   "types": "dist/src/indexer/index.d.ts",
   "scripts": {
-    "start": "node dist/src/index.js --chains=mainnet,optimism,fantom,pgn-testnet,pgn-mainnet",
-    "dev": "tsx watch src/index.ts --chains=mainnet,optimism,goerli,fantom,pgn-testnet,pgn-mainnet | pino-pretty",
+    "start": "node dist/src/index.js",
+    "dev": "tsx watch src/index.ts | pino-pretty",
     "build": "tsc",
     "lint": "eslint src",
     "test": "vitest run --reporter verbose",

--- a/src/config.ts
+++ b/src/config.ts
@@ -465,9 +465,6 @@ export function getConfig(): Config {
 
   const { values: args } = parseArgs({
     options: {
-      chains: {
-        type: "string",
-      },
       "to-block": {
         type: "string",
       },
@@ -486,17 +483,17 @@ export function getConfig(): Config {
     },
   });
 
-  if (typeof args.chains !== "string") {
-    throw new Error("Chains not provided");
-  }
-
-  const chains = args.chains.split(",").map((chainName: string) => {
-    const c = CHAINS.find((chain) => chain.name === chainName);
-    if (c === undefined) {
-      throw new Error(`Chain ${chainName} not configured`);
-    }
-    return c;
-  });
+  const chains = z
+    .string()
+    .parse(process.env.INDEXED_CHAINS)
+    .split(",")
+    .map((chainName) => {
+      const c = CHAINS.find((chain) => chain.name === chainName);
+      if (c === undefined) {
+        throw new Error(`Chain ${chainName} not configured`);
+      }
+      return c;
+    });
 
   const toBlock = z
     .union([z.coerce.number(), z.literal("latest")])


### PR DESCRIPTION
This allows to set chains per-environment without modifying package.json.