### PR TITLE
apply vote amount cap to votes

### DIFF
--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -188,6 +188,7 @@ export default class Calculator {
     }
 
     const votesWithCoefficients = await getVotesWithCoefficients(
+      this.chainId,
       round,
       applications,
       votes,
@@ -229,10 +230,13 @@ export default class Calculator {
 
     const augmented: Array<AugmentedResult> = [];
 
-    const applicationsMap = applications.reduce((all, current) => {
-      all[current.id] = current;
-      return all;
-    }, {} as Record<string, Application>);
+    const applicationsMap = applications.reduce(
+      (all, current) => {
+        all[current.id] = current;
+        return all;
+      },
+      {} as Record<string, Application>
+    );
 
     for (const id in results) {
       const calc = results[id];

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -3,7 +3,7 @@ import csv from "csv-parser";
 import { linearQF, Contribution, Calculation } from "pluralistic";
 import type { PassportProvider } from "../passport/index.js";
 import { PriceProvider } from "../prices/provider.js";
-import { tokenDecimals } from "../config.js";
+import { Chain, tokenDecimals } from "../config.js";
 import type { Round, Application, Vote } from "../indexer/types.js";
 import { getVotesWithCoefficients } from "./votes.js";
 import {
@@ -99,6 +99,7 @@ export type CalculatorOptions = {
   enablePassport?: boolean;
   ignoreSaturation?: boolean;
   overrides: Overrides;
+  chain: Chain;
 };
 
 export type AugmentedResult = Calculation & {
@@ -113,7 +114,8 @@ export default class Calculator {
   private passportProvider: PassportProvider;
   private priceProvider: PriceProvider;
   private dataProvider: DataProvider;
-  private chainId: number;
+  private chainId: number; // XXX remove
+  private chain: Chain;
   private roundId: string;
   private minimumAmountUSD: number | undefined;
   private matchingCapAmount: bigint | undefined;
@@ -126,7 +128,7 @@ export default class Calculator {
     this.passportProvider = options.passportProvider;
     this.priceProvider = options.priceProvider;
     this.dataProvider = options.dataProvider;
-    this.chainId = options.chainId;
+    this.chainId = options.chainId; // XXX remove
     this.roundId = options.roundId;
     this.minimumAmountUSD = options.minimumAmountUSD;
     this.enablePassport = options.enablePassport;
@@ -134,6 +136,7 @@ export default class Calculator {
     this.matchingCapAmount = options.matchingCapAmount;
     this.overrides = options.overrides;
     this.ignoreSaturation = options.ignoreSaturation;
+    this.chain = options.chain;
   }
 
   async calculate(): Promise<Array<AugmentedResult>> {
@@ -188,7 +191,7 @@ export default class Calculator {
     }
 
     const votesWithCoefficients = await getVotesWithCoefficients(
-      this.chainId,
+      this.chain,
       round,
       applications,
       votes,

--- a/src/calculator/tokensSettings.ts
+++ b/src/calculator/tokensSettings.ts
@@ -1,0 +1,50 @@
+import type { Vote } from "../indexer/types.js";
+
+enum ChainId {
+  Fantom = 250,
+}
+
+type TokenAddress = Lowercase<`0x${string}`>;
+
+type TokensSettings = {
+  [chainId in ChainId]: {
+    [tokenAddress: TokenAddress]: {
+      voteAmountCap: bigint | undefined;
+    };
+  };
+};
+
+export const FANTOM_GCV: TokenAddress =
+  "0x83791638da5eb2faa432aff1c65fba47c5d29510";
+
+// For now this mapping contains one single token.
+// We can continue adding tokens here, but in the future it will
+// be better to save the voteAmountCap in the roundMetadata and having
+// this fields editable in Grants Stack.
+export const tokensSettings: TokensSettings = {
+  250: {
+    [FANTOM_GCV]: {
+      voteAmountCap: BigInt(10e18),
+    },
+  },
+};
+
+export function applyVoteCap(chainId: ChainId, vote: Vote): Vote {
+  const voteAmountCap =
+    tokensSettings[chainId as ChainId]?.[
+      vote.token.toLowerCase() as TokenAddress
+    ]?.voteAmountCap;
+
+  if (voteAmountCap === undefined) {
+    return vote;
+  }
+
+  // amount : amountRoundToken = voteAmountCap : newAmountRoundToken
+  const newAmountRoundToken =
+    (BigInt(vote.amountRoundToken) * voteAmountCap) / BigInt(vote.amount);
+
+  return {
+    ...vote,
+    amountRoundToken: newAmountRoundToken.toString(),
+  };
+}

--- a/src/calculator/votes.ts
+++ b/src/calculator/votes.ts
@@ -1,5 +1,6 @@
 import type { Round, Application, Vote } from "../indexer/types.js";
 import type { PassportScore, PassportProvider } from "../passport/index.js";
+import { applyVoteCap } from "./tokensSettings.js";
 
 type VoteWithCoefficient = Vote & {
   coefficient: number;
@@ -7,6 +8,7 @@ type VoteWithCoefficient = Vote & {
 };
 
 export async function getVotesWithCoefficients(
+  chainId: number,
   round: Round,
   applications: Array<Application>,
   votes: Array<Vote>,
@@ -17,10 +19,13 @@ export async function getVotesWithCoefficients(
     passportThreshold?: number;
   }
 ): Promise<Array<VoteWithCoefficient>> {
-  const applicationMap = applications.reduce((map, application) => {
-    map[application.id] = application;
-    return map;
-  }, {} as Record<string, Application>);
+  const applicationMap = applications.reduce(
+    (map, application) => {
+      map[application.id] = application;
+      return map;
+    },
+    {} as Record<string, Application>
+  );
 
   const enablePassport =
     options.enablePassport ??
@@ -33,7 +38,8 @@ export async function getVotesWithCoefficients(
       0
   );
 
-  const votePromises = votes.map(async (vote) => {
+  const votePromises = votes.map(async (originalVote) => {
+    const vote = applyVoteCap(chainId, originalVote);
     const voter = vote.voter.toLowerCase();
     const application = applicationMap[vote.applicationId];
 

--- a/src/calculator/votes.ts
+++ b/src/calculator/votes.ts
@@ -1,3 +1,4 @@
+import { Chain } from "../config.js";
 import type { Round, Application, Vote } from "../indexer/types.js";
 import type { PassportScore, PassportProvider } from "../passport/index.js";
 import { applyVoteCap } from "./tokensSettings.js";
@@ -8,7 +9,7 @@ type VoteWithCoefficient = Vote & {
 };
 
 export async function getVotesWithCoefficients(
-  chainId: number,
+  chain: Chain,
   round: Round,
   applications: Array<Application>,
   votes: Array<Vote>,
@@ -39,7 +40,7 @@ export async function getVotesWithCoefficients(
   );
 
   const votePromises = votes.map(async (originalVote) => {
-    const vote = applyVoteCap(chainId, originalVote);
+    const vote = applyVoteCap(chain, originalVote);
     const voter = vote.voter.toLowerCase();
     const application = applicationMap[vote.applicationId];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export type Token = {
   address: string;
   decimals: number;
   priceSource: { chainId: CoingeckoSupportedChainId; address: string };
+  voteAmountCap?: bigint;
 };
 
 export type Subscription = {
@@ -275,6 +276,7 @@ export const CHAINS: Chain[] = [
         code: "GcV",
         address: "0x83791638da5EB2fAa432aff1c65fbA47c5D29510",
         decimals: 18,
+        voteAmountCap: BigInt(10e18),
         priceSource: {
           chainId: 250,
           address: "0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E",

--- a/src/http/api/v1/exports.ts
+++ b/src/http/api/v1/exports.ts
@@ -69,13 +69,18 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
       .concat(csv.stringifyRecords(pricesDuringRound));
   }
 
-  async function exportVoteCoefficientsCSV(db: JsonStorage, round: Round) {
+  async function exportVoteCoefficientsCSV(
+    chainId: number,
+    db: JsonStorage,
+    round: Round
+  ) {
     const [applications, votes] = await Promise.all([
       db.collection<Application>(`rounds/${round.id}/applications`).all(),
       db.collection<Vote>(`rounds/${round.id}/votes`).all(),
     ]);
 
     const votesWithCoefficients = await getVotesWithCoefficients(
+      chainId,
       round,
       applications,
       votes,
@@ -240,7 +245,7 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
         throw new ClientError("Round not found", 404);
       }
 
-      const body = await exportVoteCoefficientsCSV(db, round);
+      const body = await exportVoteCoefficientsCSV(chainId, db, round);
 
       res.setHeader("content-type", "text/csv");
       res.setHeader(

--- a/src/http/api/v1/exports.ts
+++ b/src/http/api/v1/exports.ts
@@ -79,8 +79,13 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
       db.collection<Vote>(`rounds/${round.id}/votes`).all(),
     ]);
 
+    const chainConfig = config.chains.find((c) => c.id === chainId);
+    if (chainConfig === undefined) {
+      throw new Error(`Chain ${chainId} not configured`);
+    }
+
     const votesWithCoefficients = await getVotesWithCoefficients(
-      chainId,
+      chainConfig,
       round,
       applications,
       votes,
@@ -290,7 +295,7 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
           break;
         }
         case "vote_coefficients": {
-          body = await exportVoteCoefficientsCSV(db, round);
+          body = await exportVoteCoefficientsCSV(chainId, db, round);
           break;
         }
         default: {

--- a/src/http/api/v1/matches.ts
+++ b/src/http/api/v1/matches.ts
@@ -77,6 +77,11 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
       overrides = await parseOverrides(buf);
     }
 
+    const chainConfig = config.chains.find((c) => c.id === chainId);
+    if (chainConfig === undefined) {
+      throw new Error(`Chain ${chainId} not configured`);
+    }
+
     const calculatorOptions: CalculatorOptions = {
       priceProvider: config.priceProvider,
       dataProvider: config.dataProvider,
@@ -93,6 +98,7 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
       enablePassport: enablePassport,
       ignoreSaturation: ignoreSaturation,
       overrides,
+      chain: chainConfig,
     };
 
     const calculator = new Calculator(calculatorOptions);

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -11,6 +11,7 @@ import { createHandler as createApiHandler } from "./api/v1/index.js";
 import { PriceProvider } from "../prices/provider.js";
 import { PassportProvider } from "../passport/index.js";
 import { DataProvider } from "../calculator/index.js";
+import { Chain } from "../config.js";
 
 export interface HttpApiConfig {
   logger: Logger;
@@ -20,6 +21,7 @@ export interface HttpApiConfig {
   priceProvider: PriceProvider;
   dataProvider: DataProvider;
   passportProvider: PassportProvider;
+  chains: Chain[];
 }
 
 interface HttpApi {

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ async function main(): Promise<void> {
       port: config.apiHttpPort,
       logger: baseLogger.child({ subsystem: "HttpApi" }),
       buildTag: config.buildTag,
+      chains: config.chains,
     });
 
     await httpApi.start();

--- a/src/test/calculator/votes.test.ts
+++ b/src/test/calculator/votes.test.ts
@@ -1,0 +1,155 @@
+import type { Vote, Round, Application } from "../../indexer/types.js";
+import type { PassportProvider } from "../../passport/index.js";
+import { describe, test, expect } from "vitest";
+import { getVotesWithCoefficients } from "../../calculator/votes.js";
+
+const noOpPassportProvider: PassportProvider = {
+  start: (_opts?: { watch: boolean } | undefined) => Promise.resolve(undefined),
+  stop: () => {},
+  getScoreByAddress: (_address: string) => Promise.resolve(undefined),
+};
+
+const round: Round = {
+  id: "0x1234",
+  amountUSD: 0,
+  votes: 0,
+  token: "0x1234",
+  matchAmount: "0x0",
+  matchAmountUSD: 0,
+  uniqueContributors: 0,
+  applicationMetaPtr: "",
+  applicationMetadata: null,
+  metaPtr: "",
+  metadata: null,
+  applicationsStartTime: "",
+  applicationsEndTime: "",
+  roundStartTime: "",
+  roundEndTime: "",
+  createdAtBlock: 0,
+  updatedAtBlock: 0,
+};
+
+const applications: Application[] = [
+  {
+    id: "application-id-1",
+    projectId: "project-id-1",
+    roundId: "0x1234",
+    status: "APPROVED",
+    amountUSD: 0,
+    votes: 0,
+    uniqueContributors: 0,
+    metadata: {
+      application: {
+        project: {
+          title: "",
+          website: "",
+          projectTwitter: "",
+          projectGithub: "",
+          userGithub: "",
+        },
+        answers: [],
+        recipient: "grant-address-1",
+      },
+    },
+    createdAtBlock: 0,
+    statusUpdatedAtBlock: 0,
+    statusSnapshots: [
+      {
+        status: "APPROVED",
+        statusUpdatedAtBlock: 0,
+      },
+    ],
+  },
+];
+
+const votes: Vote[] = [
+  // expected to be capped to 10 tokens
+  {
+    id: "vote-1",
+    projectId: "project-id-1",
+    applicationId: "application-id-1",
+    roundId: "round-id-1",
+    token: "0x83791638da5EB2fAa432aff1c65fbA47c5D29510",
+    voter: "voter-1",
+    grantAddress: "grant-address-1",
+    // higher than the cap (10e18)
+    amount: BigInt(20e18).toString(),
+    amountUSD: 20,
+    amountRoundToken: BigInt(50e18).toString(),
+  },
+
+  // not expected to be capped to 10 tokens
+  // because token is not in the token settings
+  {
+    id: "vote-1",
+    projectId: "project-id-1",
+    applicationId: "application-id-1",
+    roundId: "round-id-1",
+    token: "0x1234",
+    voter: "voter-1",
+    grantAddress: "grant-address-1",
+    // higher than the cap (10e18)
+    amount: BigInt(20e18).toString(),
+    amountUSD: 20,
+    amountRoundToken: BigInt(50e18).toString(),
+  },
+];
+
+describe("getVotesWithCoefficients", () => {
+  describe("should call applyVoteCap", () => {
+    test("returns capped vote", async () => {
+      const testVoteIndex = 0;
+
+      const res = await getVotesWithCoefficients(
+        250,
+        round,
+        applications,
+        votes,
+        noOpPassportProvider,
+        {}
+      );
+
+      expect(res[testVoteIndex]).toEqual({
+        ...votes[testVoteIndex],
+        coefficient: 1,
+        amountRoundToken: BigInt(25e18).toString(),
+      });
+    });
+
+    test("doesn't cap votes with chainId not recognized", async () => {
+      const testVoteIndex = 0;
+
+      const res = await getVotesWithCoefficients(
+        9999,
+        round,
+        applications,
+        votes,
+        noOpPassportProvider,
+        {}
+      );
+
+      expect(res[testVoteIndex]).toEqual({
+        ...votes[testVoteIndex],
+        coefficient: 1,
+      });
+    });
+
+    test("doesn't cap votes with tokens not recognized", async () => {
+      const testVoteIndex = 1;
+
+      const res = await getVotesWithCoefficients(
+        250,
+        round,
+        applications,
+        votes,
+        noOpPassportProvider,
+        {}
+      );
+
+      expect(res[testVoteIndex]).toEqual({
+        ...votes[testVoteIndex],
+        coefficient: 1,
+      });
+    });
+  });
+});

--- a/src/test/calculator/votes.test.ts
+++ b/src/test/calculator/votes.test.ts
@@ -2,6 +2,7 @@ import type { Vote, Round, Application } from "../../indexer/types.js";
 import type { PassportProvider } from "../../passport/index.js";
 import { describe, test, expect } from "vitest";
 import { getVotesWithCoefficients } from "../../calculator/votes.js";
+import { Chain } from "../../config.js";
 
 const noOpPassportProvider: PassportProvider = {
   start: (_opts?: { watch: boolean } | undefined) => Promise.resolve(undefined),
@@ -95,13 +96,28 @@ const votes: Vote[] = [
   },
 ];
 
+const MOCK_CHAIN = {
+  id: 250,
+  tokens: [
+    {
+      code: "GcV",
+      address: "0x83791638da5EB2fAa432aff1c65fbA47c5D29510",
+      voteAmountCap: BigInt(10e18),
+    },
+    {
+      code: "Dummy",
+      address: "0x1234",
+    },
+  ],
+} as unknown as Chain;
+
 describe("getVotesWithCoefficients", () => {
-  describe("should call applyVoteCap", () => {
-    test("returns capped vote", async () => {
+  describe("should take voteAmountCap into conisderation", () => {
+    test("returns capped vote if capping is defined for token", async () => {
       const testVoteIndex = 0;
 
       const res = await getVotesWithCoefficients(
-        250,
+        MOCK_CHAIN,
         round,
         applications,
         votes,
@@ -116,29 +132,11 @@ describe("getVotesWithCoefficients", () => {
       });
     });
 
-    test("doesn't cap votes with chainId not recognized", async () => {
-      const testVoteIndex = 0;
-
-      const res = await getVotesWithCoefficients(
-        9999,
-        round,
-        applications,
-        votes,
-        noOpPassportProvider,
-        {}
-      );
-
-      expect(res[testVoteIndex]).toEqual({
-        ...votes[testVoteIndex],
-        coefficient: 1,
-      });
-    });
-
-    test("doesn't cap votes with tokens not recognized", async () => {
+    test("doesn't cap votes if capping isn't defined for token", async () => {
       const testVoteIndex = 1;
 
       const res = await getVotesWithCoefficients(
-        250,
+        MOCK_CHAIN,
         round,
         applications,
         votes,

--- a/src/test/http/app.test.ts
+++ b/src/test/http/app.test.ts
@@ -14,6 +14,7 @@ import {
 import { PriceProvider } from "../../prices/provider.js";
 import { Logger } from "pino";
 import { PassportScore } from "../../passport/index.js";
+import { Chain } from "../../config.js";
 
 vi.spyOn(os, "hostname").mockReturnValue("dummy-hostname");
 
@@ -39,6 +40,18 @@ export class TestPriceProvider {
     return Promise.resolve({ amount: 0 });
   }
 }
+
+const MOCK_CHAINS = [
+  {
+    id: 1,
+    tokens: [
+      {
+        code: "ETH",
+        address: "0x0000000000000000000000000000000000000000",
+      },
+    ],
+  },
+] as Chain[];
 
 class TestPassportProvider {
   _fixture: PassportScore[] | null = null;
@@ -102,6 +115,7 @@ describe("server", () => {
           "1/rounds.json": "rounds",
           "passport_scores.json": "passport_scores",
         }) as DataProvider,
+        chains: MOCK_CHAINS,
       }).app;
     });
 
@@ -145,6 +159,7 @@ describe("server", () => {
             "1/rounds.json": [], // empty file so the round won't be found
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         });
 
         const resp = await request(app).get(
@@ -166,6 +181,7 @@ describe("server", () => {
             "1/rounds.json": [], // empty file so the round won't be found
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         });
 
         const resp = await request(app).get(
@@ -187,6 +203,7 @@ describe("server", () => {
             "1/rounds.json": [], // empty file so the round won't be found
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         });
 
         const resp = await request(app).get(
@@ -208,6 +225,7 @@ describe("server", () => {
             "1/rounds.json": [], // empty file so the round won't be found
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         });
 
         const resp = await request(app).get(
@@ -229,6 +247,7 @@ describe("server", () => {
             "1/rounds.json": [], // empty file so the round won't be found
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         });
 
         const resp = await request(app).get(
@@ -253,6 +272,7 @@ describe("server", () => {
             "1/rounds.json": "rounds",
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         }).app;
       });
 
@@ -329,6 +349,7 @@ describe("server", () => {
             ],
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         }).app;
       });
 
@@ -396,6 +417,7 @@ describe("server", () => {
             "1/rounds.json": "rounds",
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         }).app;
       });
 
@@ -462,6 +484,7 @@ describe("server", () => {
             "1/rounds.json": "rounds",
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         }).app;
       });
 
@@ -590,6 +613,7 @@ describe("server", () => {
             "1/rounds.json": "rounds",
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         }).app;
       });
 
@@ -801,6 +825,7 @@ describe("server", () => {
             "1/rounds.json": "rounds",
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         }).app;
       });
 
@@ -963,6 +988,7 @@ describe("server", () => {
             "1/rounds.json": "rounds",
           }) as DataProvider,
           buildTag: "123abc",
+          chains: MOCK_CHAINS,
         }).app;
       });
 


### PR DESCRIPTION
closes https://github.com/gitcoinco/allo-indexer/issues/260

Each vote is passed to `applyVoteCap`; the amount is capped if in the settings we have a cap for a vote chainId/tokenAddress.

We apply the cap to `amountRoundToken`, which is the amount passed to the `linearQF` function.