### PR TITLE
fix: catch errors from async calls

### DIFF
--- a/src/indexer/handleEvent.ts
+++ b/src/indexer/handleEvent.ts
@@ -290,15 +290,15 @@ async function handleEvent(
     }
 
     case "MatchAmountUpdated": {
-      return matchAmountUpdated(event, { priceProvider, db, chainId });
+      return await matchAmountUpdated(event, { priceProvider, db, chainId });
     }
 
     case "RoundMetaPtrUpdated": {
-      return roundMetaPtrUpdated(event, { ipfsGet, db });
+      return await roundMetaPtrUpdated(event, { ipfsGet, db });
     }
 
     case "ApplicationMetaPtrUpdated": {
-      return applicationMetaPtrUpdated(event, { ipfsGet, db });
+      return await applicationMetaPtrUpdated(event, { ipfsGet, db });
     }
 
     case "NewProjectApplication": {


### PR DESCRIPTION
`handleEvent` is delegating to event-handling functions but not `await`ing them, so an error in `matchAmountUpdated` escapes the try/catch in `handleEvent` and doesn't get logged.