### PR TITLE
enh: initial catchup performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@sentry/node": "^7.51.0",
-        "chainsauce": "github:gitcoinco/chainsauce#49bee375cc230097ef024c0f7107c13393f5c2ac",
+        "chainsauce": "github:gitcoinco/chainsauce#main",
         "cors": "^2.8.5",
         "csv-parser": "^3.0.0",
         "csv-writer": "^1.6.0",
@@ -2790,8 +2790,7 @@
     },
     "node_modules/chainsauce": {
       "version": "1.0.19",
-      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#49bee375cc230097ef024c0f7107c13393f5c2ac",
-      "integrity": "sha512-K0+BLgD8v1SmGPiqdLNkp4UcUEDgUE9asuQpV1A5IuntUgPj7seyOdv0E6skkFx9J0YqfGxc5SEJ7qeEgQXoGw==",
+      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#d64c96523160cf6341a13388299d2fa20dc3232f",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.2.0",
@@ -9069,9 +9068,8 @@
       }
     },
     "chainsauce": {
-      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#49bee375cc230097ef024c0f7107c13393f5c2ac",
-      "integrity": "sha512-K0+BLgD8v1SmGPiqdLNkp4UcUEDgUE9asuQpV1A5IuntUgPj7seyOdv0E6skkFx9J0YqfGxc5SEJ7qeEgQXoGw==",
-      "from": "chainsauce@github:gitcoinco/chainsauce#49bee375cc230097ef024c0f7107c13393f5c2ac",
+      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#d64c96523160cf6341a13388299d2fa20dc3232f",
+      "from": "chainsauce@github:gitcoinco/chainsauce#main",
       "requires": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@sentry/node": "^7.51.0",
-        "chainsauce": "github:gitcoinco/chainsauce",
+        "chainsauce": "github:gitcoinco/chainsauce#49bee375cc230097ef024c0f7107c13393f5c2ac",
         "cors": "^2.8.5",
         "csv-parser": "^3.0.0",
         "csv-writer": "^1.6.0",
@@ -1342,6 +1342,97 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.1.1.tgz",
+      "integrity": "sha512-6RlbiOAi6L6uUYF4/CDEkDZQnKw0XDsFJVrEpnib8rAx2WRMOsUyAdgnvDpX/fdkDWxtqE+NHwF465llI2wR0g==",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@npmcli/fs": {
@@ -2699,14 +2790,118 @@
     },
     "node_modules/chainsauce": {
       "version": "1.0.19",
-      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#d46ea64d1538b6ca197899aad1dfd5ae01b484ea",
+      "resolved": "git+ssh://git@github.com/gitcoinco/chainsauce.git#49bee375cc230097ef024c0f7107c13393f5c2ac",
+      "integrity": "sha512-K0+BLgD8v1SmGPiqdLNkp4UcUEDgUE9asuQpV1A5IuntUgPj7seyOdv0E6skkFx9J0YqfGxc5SEJ7qeEgQXoGw==",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",
         "express": "^4.18.2",
-        "node-fetch": "^3.3.1",
+        "fetch-retry": "^5.0.6",
+        "make-fetch-happen": "^13.0.0",
         "pino": "^8.14.1"
+      }
+    },
+    "node_modules/chainsauce/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/chainsauce/node_modules/cacache": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.0.tgz",
+      "integrity": "sha512-I7mVOPl3PUCeRub1U8YoGz2Lqv9WOBpobZ8RyWFXmReuILz+3OAyTa5oH3QPdtKZD7N0Yk00aLfzn0qvp8dZ1w==",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/chainsauce/node_modules/glob": {
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/chainsauce/node_modules/lru-cache": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/chainsauce/node_modules/make-fetch-happen": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.0.tgz",
+      "integrity": "sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==",
+      "dependencies": {
+        "@npmcli/agent": "^2.0.0",
+        "cacache": "^18.0.0",
+        "http-cache-semantics": "^4.1.1",
+        "is-lambda": "^1.0.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "ssri": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/chainsauce/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/chainsauce/node_modules/minipass": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/check-error": {
@@ -3039,13 +3234,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
       "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -3756,27 +3944,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fetch-retry": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
@@ -3880,16 +4047,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -5171,39 +5328,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp-build": {
@@ -7046,13 +7170,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/well-known-symbols": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
@@ -7894,6 +8011,73 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@npmcli/agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.1.1.tgz",
+      "integrity": "sha512-6RlbiOAi6L6uUYF4/CDEkDZQnKw0XDsFJVrEpnib8rAx2WRMOsUyAdgnvDpX/fdkDWxtqE+NHwF465llI2wR0g==",
+      "requires": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+          "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        },
+        "lru-cache": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "socks-proxy-agent": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+          "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "^4.3.4",
+            "socks": "^2.7.1"
+          }
+        }
       }
     },
     "@npmcli/fs": {
@@ -8885,14 +9069,93 @@
       }
     },
     "chainsauce": {
-      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#d46ea64d1538b6ca197899aad1dfd5ae01b484ea",
-      "from": "chainsauce@github:gitcoinco/chainsauce",
+      "version": "git+ssh://git@github.com/gitcoinco/chainsauce.git#49bee375cc230097ef024c0f7107c13393f5c2ac",
+      "integrity": "sha512-K0+BLgD8v1SmGPiqdLNkp4UcUEDgUE9asuQpV1A5IuntUgPj7seyOdv0E6skkFx9J0YqfGxc5SEJ7qeEgQXoGw==",
+      "from": "chainsauce@github:gitcoinco/chainsauce#49bee375cc230097ef024c0f7107c13393f5c2ac",
       "requires": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",
         "express": "^4.18.2",
-        "node-fetch": "^3.3.1",
+        "fetch-retry": "^5.0.6",
+        "make-fetch-happen": "^13.0.0",
         "pino": "^8.14.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "cacache": {
+          "version": "18.0.0",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.0.tgz",
+          "integrity": "sha512-I7mVOPl3PUCeRub1U8YoGz2Lqv9WOBpobZ8RyWFXmReuILz+3OAyTa5oH3QPdtKZD7N0Yk00aLfzn0qvp8dZ1w==",
+          "requires": {
+            "@npmcli/fs": "^3.1.0",
+            "fs-minipass": "^3.0.0",
+            "glob": "^10.2.2",
+            "lru-cache": "^10.0.1",
+            "minipass": "^7.0.3",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "p-map": "^4.0.0",
+            "ssri": "^10.0.0",
+            "tar": "^6.1.11",
+            "unique-filename": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "10.3.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+          "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^2.0.3",
+            "minimatch": "^9.0.1",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+            "path-scurry": "^1.10.1"
+          }
+        },
+        "lru-cache": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
+        },
+        "make-fetch-happen": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.0.tgz",
+          "integrity": "sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==",
+          "requires": {
+            "@npmcli/agent": "^2.0.0",
+            "cacache": "^18.0.0",
+            "http-cache-semantics": "^4.1.1",
+            "is-lambda": "^1.0.1",
+            "minipass": "^7.0.2",
+            "minipass-fetch": "^3.0.0",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "promise-retry": "^2.0.1",
+            "ssri": "^10.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
+        }
       }
     },
     "check-error": {
@@ -9147,9 +9410,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
       "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
-    },
-    "data-uri-to-buffer": {
-      "version": "4.0.1"
     },
     "date-fns": {
       "version": "2.30.0",
@@ -9662,13 +9922,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "fetch-retry": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
@@ -9740,12 +9993,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "formidable": {
@@ -10605,17 +10852,6 @@
             "lru-cache": "^6.0.0"
           }
         }
-      }
-    },
-    "node-domexception": {
-      "version": "1.0.0"
-    },
-    "node-fetch": {
-      "version": "3.3.1",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-gyp-build": {
@@ -11811,9 +12047,6 @@
           "dev": true
         }
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1"
     },
     "well-known-symbols": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "ISC",
   "dependencies": {
     "@sentry/node": "^7.51.0",
-    "chainsauce": "github:gitcoinco/chainsauce#49bee375cc230097ef024c0f7107c13393f5c2ac",
+    "chainsauce": "github:gitcoinco/chainsauce#main",
     "cors": "^2.8.5",
     "csv-parser": "^3.0.0",
     "csv-writer": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "ISC",
   "dependencies": {
     "@sentry/node": "^7.51.0",
-    "chainsauce": "github:gitcoinco/chainsauce",
+    "chainsauce": "github:gitcoinco/chainsauce#49bee375cc230097ef024c0f7107c13393f5c2ac",
     "cors": "^2.8.5",
     "csv-parser": "^3.0.0",
     "csv-writer": "^1.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,28 +194,25 @@ async function catchupAndWatchChain(
 
       chainLogger.trace(`Fetching ${url}`);
 
-      try {
-        const res = await fetch(url, {
-          timeout: 2000,
-          onRetry(cause) {
-            chainLogger.debug(`Retrying IPFS request ${String(cause)}`);
-          },
-          retry: { retries: 3, minTimeout: 2000, maxTimeout: 60 * 10000 },
-          // IPFS data is immutable, we can rely entirely on the cache when present
-          cache: "force-cache",
-          cachePath:
-            config.cacheDir !== null
-              ? path.join(config.cacheDir, "ipfs")
-              : undefined,
-        });
+      const res = await fetch(url, {
+        timeout: 2000,
+        onRetry(cause) {
+          chainLogger.debug({
+            msg: "Retrying IPFS request",
+            url: url,
+            err: cause,
+          });
+        },
+        retry: { retries: 3, minTimeout: 2000, maxTimeout: 60 * 10000 },
+        // IPFS data is immutable, we can rely entirely on the cache when present
+        cache: "force-cache",
+        cachePath:
+          config.cacheDir !== null
+            ? path.join(config.cacheDir, "ipfs")
+            : undefined,
+      });
 
-        return (await res.json()) as T;
-      } catch (err) {
-        chainLogger.warn({
-          msg: "failed to load IPFS file",
-          err,
-        });
-      }
+      return (await res.json()) as T;
     };
 
     await rpcProvider.getNetwork();

--- a/src/indexer/handleEvent.ts
+++ b/src/indexer/handleEvent.ts
@@ -661,7 +661,7 @@ async function handleEvent(
           .insert({
             ...vote,
             roundName: round.metadata?.name,
-            projectTitle: application.metadata?.application.project.title,
+            projectTitle: application.metadata?.application?.project?.title,
             roundStartTime: round.roundStartTime,
             roundEndTime: round.roundEndTime,
           }),


### PR DESCRIPTION
This aims to fix the current blocking issue with deployments by reducing the time it takes to do an initial catch up without making too many changes.

**Note: There's a temporary change to auto deploy this branch to staging to test deployments, remove before merging.**

Depends on https://github.com/gitcoinco/chainsauce/pull/2 https://github.com/gitcoinco/chainsauce/pull/1

## IPFS

Some IPFS files do not seem to exist anymore, I can see them on the Pinata dashboard but the IPFS server never returns a response, this happens even when using different gateways, example: https://ipfs-grants-stack.gitcoin.co/ipfs/bafkreig47gxcq5j2mkligw2odnitqqhxfhs34mz5r6yry4jtfgqr54f6yq

This holds the deployments due to high timeouts in the IPFS fetch and finally crashes the indexer when it fails. We could treat it as a warning as the hash comes from the user.

## RPC (Chainauce)

Chainsauce's RPC fetching depends on `node-fetch` and this issue was affecting us: https://github.com/node-fetch/node-fetch/issues/1735

The retry logic is also a bit aggressive and it could overwhelm smaller servers like Fantom or PGN testnet.

## Storage access by ID (Chainsauce)

On each vote we check whether the contributor has already donated or not, we do this by looking up the contributor address, this can get expensive as the search is linear and the number of contributors can be very high, this also happens inside the tightest loop of the indexing process so it affects the indexing time considerably, Chainsauce now implements and index to cover cases when we want to find a record by ID.

## Memory leak (Chainsauce)

Fixed a bug where Chainsauce kept all the JSON files in memory, they're now be garbage collected as intended when written to the disk. The indexer should use a lot less memory now, looks like production is at 3GB and staging at 1GB running the same chains.