### PR TITLE
chore: remove unused collections

### DIFF
--- a/src/indexer/handleEvent.ts
+++ b/src/indexer/handleEvent.ts
@@ -641,11 +641,6 @@ async function handleEvent(
               project.uniqueContributors +
               (isNewapplicationContributor ? 1 : 0),
           })),
-        db
-          .collection<Vote>(
-            `rounds/${event.args.roundAddress}/applications/${applicationId}/votes`
-          )
-          .insert(vote),
       ]);
 
       const contributorPartitionedPath = vote.voter

--- a/src/indexer/handleEvent.ts
+++ b/src/indexer/handleEvent.ts
@@ -686,11 +686,6 @@ async function handleEvent(
         db
           .collection<Vote>(`rounds/${event.args.roundAddress}/votes`)
           .insert(vote),
-        db
-          .collection<Vote>(
-            `rounds/${event.args.roundAddress}/projects/${event.args.projectId}/votes`
-          )
-          .insert(vote),
       ]);
 
       break;


### PR DESCRIPTION
This removes vote collections partitioned by projectId and applicationId, the only votes collection we need in the calculator is the one partitioned by roundId.