### PR TITLE
fix: make dependency among i/o operations explicit

### DIFF
--- a/src/indexer/handleEvent.ts
+++ b/src/indexer/handleEvent.ts
@@ -251,6 +251,9 @@ async function handleEvent(
         db.collection(`rounds/${roundId}/applications`).replaceAll([]),
         db.collection(`rounds/${roundId}/votes`).replaceAll([]),
         db.collection(`rounds/${roundId}/contributors`).replaceAll([]),
+      ]);
+
+      await Promise.all([
         matchAmountUpdated(
           {
             ...event,


### PR DESCRIPTION


The order of some operations is implicitly enforced by chainsauce using blocking I/O. This change makes the order of those operations explicit and independent of blocking / non-blocking I/O.

Necessary if something like https://github.com/gitcoinco/chainsauce/pull/3 lands or for correctness/robustness in general.
