### PR TITLE
fix: create chain data directory if it doesn't exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ async function catchupAndWatchPassport(
   const logger = config.baseLogger.child({ subsystem: "PassportProvider" });
   try {
     await fs.mkdir(config.storageDir, { recursive: true });
+    await fs.mkdir(config.chainDataDir, { recursive: true });
 
     const passportProvider = createPassportProvider({
       logger,


### PR DESCRIPTION
the chain data directory is not created before starting the passport service, leading to an error when first writing `passport_scores.json`, the directory is eventually created so the problem doesn't happen after a restart

note: `chainDataDir` is actually `${storageDir}/chainData` but as far as the passport service is concerned they could be two totally different directories, so we create both of them